### PR TITLE
Add pubspec topics for pub.dev

### DIFF
--- a/packages/chirp/pubspec.yaml
+++ b/packages/chirp/pubspec.yaml
@@ -4,6 +4,10 @@ description: >-
   child loggers, structured logging, and span-based formatting.
 version: 0.6.0
 repository: https://github.com/passsy/chirp
+topics:
+  - logging
+  - ansi
+  - error
 
 environment:
   sdk: ^3.0.0


### PR DESCRIPTION
## Summary
- Add topics (`logging`, `ansi`, `error`) to pubspec.yaml for better discoverability on pub.dev

## Test plan
- [x] Verify pubspec.yaml is valid with `./chrp analyze`

🤖 Generated with [Claude Code](https://claude.com/claude-code)