### PR TITLE
Fix Aligned span ignoring ANSI codes in padding calculation

### DIFF
--- a/packages/chirp/lib/src/span/spans.dart
+++ b/packages/chirp/lib/src/span/spans.dart
@@ -437,17 +437,29 @@ class Aligned extends SingleChildSpan {
     final b = buffer.createChildBuffer();
     child?.render(b);
     final content = b.toString();
+    // Use visible length (excluding ANSI escape codes) for padding calculation
+    final visibleLength = stripAnsiCodes(content).length;
     final padded = switch (align) {
-      HorizontalAlign.left => content.padRight(width),
-      HorizontalAlign.right => content.padLeft(width),
-      HorizontalAlign.center => _padCenter(content, width),
+      HorizontalAlign.left => _padRight(content, width, visibleLength),
+      HorizontalAlign.right => _padLeft(content, width, visibleLength),
+      HorizontalAlign.center => _padCenter(content, width, visibleLength),
     };
     buffer.write(padded);
   }
 
-  static String _padCenter(String content, int width) {
-    if (content.length >= width) return content;
-    final totalPadding = width - content.length;
+  static String _padLeft(String content, int width, int visibleLength) {
+    if (visibleLength >= width) return content;
+    return '${' ' * (width - visibleLength)}$content';
+  }
+
+  static String _padRight(String content, int width, int visibleLength) {
+    if (visibleLength >= width) return content;
+    return '$content${' ' * (width - visibleLength)}';
+  }
+
+  static String _padCenter(String content, int width, int visibleLength) {
+    if (visibleLength >= width) return content;
+    final totalPadding = width - visibleLength;
     final leftPadding = totalPadding ~/ 2;
     final rightPadding = totalPadding - leftPadding;
     return '${' ' * leftPadding}$content${' ' * rightPadding}';

--- a/packages/chirp/test/span_transformer_test.dart
+++ b/packages/chirp/test/span_transformer_test.dart
@@ -1189,6 +1189,88 @@ void main() {
       expect(result, isNot(contains('Hello')));
     });
   });
+
+  group('Aligned', () {
+    test('pads plain text to width', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.ansi256,
+        ),
+      );
+      Aligned(
+        width: 10,
+        align: HorizontalAlign.left,
+        child: PlainText('hello'),
+      ).render(buffer);
+
+      expect(buffer.toString(), 'hello     ');
+    });
+
+    test('ignores ANSI codes when calculating visible width', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.ansi256,
+        ),
+      );
+      Aligned(
+        width: 10,
+        align: HorizontalAlign.left,
+        child: AnsiStyled(
+          foreground: Ansi16.red,
+          child: PlainText('hello'),
+        ),
+      ).render(buffer);
+
+      final result = buffer.toString();
+      // The visible content is 'hello' (5 chars) + 5 spaces of padding
+      // ANSI codes should NOT be counted towards the width
+      final stripped = stripAnsiCodes(result);
+      expect(stripped, 'hello     ');
+      expect(stripped.length, 10);
+    });
+
+    test('right align ignores ANSI codes', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.ansi256,
+        ),
+      );
+      Aligned(
+        width: 10,
+        align: HorizontalAlign.right,
+        child: AnsiStyled(
+          foreground: Ansi16.blue,
+          child: PlainText('hello'),
+        ),
+      ).render(buffer);
+
+      final result = buffer.toString();
+      final stripped = stripAnsiCodes(result);
+      expect(stripped, '     hello');
+      expect(stripped.length, 10);
+    });
+
+    test('center align ignores ANSI codes', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.ansi256,
+        ),
+      );
+      Aligned(
+        width: 10,
+        align: HorizontalAlign.center,
+        child: AnsiStyled(
+          foreground: Ansi16.green,
+          child: PlainText('hi'),
+        ),
+      ).render(buffer);
+
+      final result = buffer.toString();
+      final stripped = stripAnsiCodes(result);
+      expect(stripped, '    hi    ');
+      expect(stripped.length, 10);
+    });
+  });
 }
 
 /// Builds to Timestamp (which builds to PlainText).


### PR DESCRIPTION
## Summary
- Fixed `Aligned` span to use `stripAnsiCodes()` when calculating visible width for padding
- Previously, ANSI escape sequences (colors, styles) were included in the length calculation, causing incorrect alignment
- Added tests for left, right, and center alignment with ANSI-styled content

## Test plan
- [x] Added tests in `span_transformer_test.dart` for all alignment modes with ANSI content
- [x] Verified existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)