### PR TITLE
Add DataKey and DataValue spans, improve InlineData composability

### DIFF
--- a/packages/chirp/lib/chirp_spans.dart
+++ b/packages/chirp/lib/chirp_spans.dart
@@ -32,6 +32,8 @@ export 'package:chirp/src/span/spans.dart'
         ChirpLogo,
         ClassName,
         DartSourceCodeLocation,
+        DataKey,
+        DataValue,
         EmptySpan,
         ErrorSpan,
         HorizontalAlign,

--- a/packages/chirp/lib/src/formatters/compact_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/compact_message_formatter.dart
@@ -38,7 +38,12 @@ class CompactChirpMessageFormatter extends SpanBasedFormatter {
       Surrounded(prefix: Whitespace(), child: ClassName.fromRecord(record)),
       Whitespace(),
       LogMessage(record.message),
-      if (record.data.isNotEmpty) InlineData(record.data),
+      if (record.data.isNotEmpty)
+        Surrounded(
+          prefix: PlainText(' ('),
+          child: InlineData(record.data),
+          suffix: PlainText(')'),
+        ),
       if (record.error != null) ...[
         NewLine(),
         ErrorSpan(record.error),

--- a/packages/chirp/lib/src/formatters/rainbow_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/rainbow_message_formatter.dart
@@ -165,7 +165,11 @@ LogSpan _buildRainbowLogSpan({
   final data = record.data;
   if (data.isNotEmpty) {
     final dataSpan = switch (options.data) {
-      DataPresentation.inline => InlineData(data),
+      DataPresentation.inline => Surrounded(
+          prefix: PlainText(' ('),
+          child: InlineData(data),
+          suffix: PlainText(')'),
+        ),
       DataPresentation.multiline => MultilineData(data),
     };
     if (levelColor == null) {

--- a/packages/chirp/lib/src/formatters/simple_console_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/simple_console_message_formatter.dart
@@ -171,7 +171,13 @@ LogSpan _buildSimpleLogSpan({
 
   // Structured data inline with message
   if (showData && record.data.isNotEmpty) {
-    spans.add(InlineData(record.data));
+    spans.add(
+      Surrounded(
+        prefix: PlainText(' ('),
+        child: InlineData(record.data),
+        suffix: PlainText(')'),
+      ),
+    );
   }
 
   // Error on new line

--- a/packages/chirp/test/span_transformer_test.dart
+++ b/packages/chirp/test/span_transformer_test.dart
@@ -1272,6 +1272,144 @@ void main() {
       expect(stripped.length, 10);
     });
   });
+
+  group('DataKey', () {
+    test('renders simple key', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      DataKey('userId').render(buffer);
+      expect(buffer.toString(), 'userId');
+    });
+
+    test('quotes key with spaces', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      DataKey('key with spaces').render(buffer);
+      expect(buffer.toString(), '"key with spaces"');
+    });
+  });
+
+  group('DataValue', () {
+    test('renders string value quoted', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      DataValue('hello').render(buffer);
+      expect(buffer.toString(), '"hello"');
+    });
+
+    test('renders number without quotes', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      DataValue(42).render(buffer);
+      expect(buffer.toString(), '42');
+    });
+
+    test('renders boolean without quotes', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      DataValue(true).render(buffer);
+      expect(buffer.toString(), 'true');
+    });
+
+    test('renders null as null', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      DataValue(null).render(buffer);
+      expect(buffer.toString(), 'null');
+    });
+  });
+
+  group('InlineData', () {
+    test('renders empty for null data', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      renderSpan(InlineData(null), buffer);
+      expect(buffer.toString(), '');
+    });
+
+    test('renders empty for empty map', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      renderSpan(InlineData({}), buffer);
+      expect(buffer.toString(), '');
+    });
+
+    test('renders single key-value pair', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      renderSpan(InlineData({'userId': 'abc123'}), buffer);
+      expect(buffer.toString(), 'userId: "abc123"');
+    });
+
+    test('renders multiple key-value pairs with separator', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      renderSpan(InlineData({'userId': 'abc', 'action': 'login'}), buffer);
+      expect(buffer.toString(), 'userId: "abc", action: "login"');
+    });
+
+    test('uses custom entry separator', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      renderSpan(
+        InlineData(
+          {'a': 1, 'b': 2},
+          entrySeparatorBuilder: () => PlainText(' | '),
+        ),
+        buffer,
+      );
+      expect(buffer.toString(), 'a: 1 | b: 2');
+    });
+
+    test('uses custom key-value separator', () {
+      final buffer = ConsoleMessageBuffer(
+        capabilities: const TerminalCapabilities(
+          colorSupport: TerminalColorSupport.none,
+        ),
+      );
+      renderSpan(
+        InlineData(
+          {'key': 'value'},
+          keyValueSeparatorBuilder: () => PlainText('='),
+        ),
+        buffer,
+      );
+      expect(buffer.toString(), 'key="value"');
+    });
+  });
 }
 
 /// Builds to Timestamp (which builds to PlainText).


### PR DESCRIPTION
Add `DataKey` and `DataValue` spans for individual key/value rendering, and refactor `InlineData` to use span composition.

### New Spans

```dart
// Render a single key (auto-quotes if needed)
DataKey("userId")           // → userId
DataKey("key with spaces")  // → "key with spaces"

// Render a single value (type-aware formatting)
DataValue("hello")  // → "hello"
DataValue(42)       // → 42
DataValue(true)     // → true
DataValue(null)     // → null
```

### InlineData Changes

`InlineData` now uses span composition internally, enabling custom separators:

```dart
// Default output
InlineData({"userId": "abc", "count": 42})
// → userId: "abc", count: 42

// Custom separators
InlineData(
  {"a": 1, "b": 2},
  entrySeparatorBuilder: () => PlainText(" | "),
  keyValueSeparatorBuilder: () => PlainText("="),
)
// → a=1 | b=2
```

The parentheses wrapper is now handled by formatters via `Surrounded`, making `InlineData` output cleaner for reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)