### PR TITLE
Move span exports to dedicated chirp_spans.dart library

### DIFF
--- a/examples/simple/bin/color_support.dart
+++ b/examples/simple/bin/color_support.dart
@@ -2,6 +2,7 @@
 import 'dart:io';
 
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 import 'package:chirp/src/platform/platform_info.dart';
 
 void main() {

--- a/examples/simple/bin/main.dart
+++ b/examples/simple/bin/main.dart
@@ -12,6 +12,7 @@
 /// - interceptors.dart - Filtering and transforming logs
 /// - library.dart / app.dart - Library logger adoption
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 
 void main() {
   // Configure with span transformers for custom formatting

--- a/packages/chirp/lib/chirp.dart
+++ b/packages/chirp/lib/chirp.dart
@@ -27,8 +27,6 @@ export 'package:chirp/src/ansi/ansi16.dart' show Ansi16;
 export 'package:chirp/src/ansi/ansi256.g.dart' show Ansi256;
 export 'package:chirp/src/ansi/console_color.dart'
     show ConsoleColor, DefaultColor, IndexedColor, RgbColor;
-export 'package:chirp/src/ansi/hash_colors.dart'
-    show ColorSaturation, colorForHash;
 export 'package:chirp/src/core/chirp_interceptor.dart' show ChirpInterceptor;
 export 'package:chirp/src/core/chirp_logger.dart' show ChirpLogger;
 export 'package:chirp/src/core/chirp_root.dart'
@@ -53,42 +51,6 @@ export 'package:chirp/src/platform/color_support.dart'
     show TerminalColorSupport;
 export 'package:chirp/src/platform/terminal_capabilities.dart'
     show TerminalCapabilities;
-export 'package:chirp/src/span/span_based_formatter.dart'
-    show SpanBasedFormatter, SpanFormatOptions, SpanTransformer;
-export 'package:chirp/src/span/span_foundation.dart'
-    show
-        LeafSpan,
-        LogSpan,
-        MultiChildSpan,
-        SingleChildSpan,
-        SlottedSpan,
-        renderSpan;
-export 'package:chirp/src/span/spans.dart'
-    show
-        Aligned,
-        AnsiStyled,
-        Bordered,
-        BoxBorderChars,
-        BoxBorderStyle,
-        BracketedLogLevel,
-        ChirpLogo,
-        ClassName,
-        DartSourceCodeLocation,
-        EmptySpan,
-        ErrorSpan,
-        HorizontalAlign,
-        InlineData,
-        LogMessage,
-        LoggerName,
-        MethodName,
-        MultilineData,
-        NewLine,
-        PlainText,
-        SpanSequence,
-        StackTraceSpan,
-        Surrounded,
-        Timestamp,
-        Whitespace;
 export 'package:chirp/src/utils/stack_trace_util.dart'
     show StackFrameInfo, getCallerInfo, parseStackFrame;
 export 'package:chirp/src/writers/console_writer.dart'

--- a/packages/chirp/lib/chirp_spans.dart
+++ b/packages/chirp/lib/chirp_spans.dart
@@ -9,6 +9,41 @@ library;
 
 import 'package:meta/meta.dart';
 
-export 'package:chirp/src/span/span_based_formatter.dart';
-export 'package:chirp/src/span/span_foundation.dart';
-export 'package:chirp/src/span/spans.dart';
+export 'package:chirp/src/ansi/hash_colors.dart'
+    show ColorSaturation, colorForHash;
+export 'package:chirp/src/span/span_based_formatter.dart'
+    show SpanBasedFormatter, SpanFormatOptions, SpanTransformer;
+export 'package:chirp/src/span/span_foundation.dart'
+    show
+        LeafSpan,
+        LogSpan,
+        MultiChildSpan,
+        SingleChildSpan,
+        SlottedSpan,
+        renderSpan;
+export 'package:chirp/src/span/spans.dart'
+    show
+        Aligned,
+        AnsiStyled,
+        Bordered,
+        BoxBorderChars,
+        BoxBorderStyle,
+        BracketedLogLevel,
+        ChirpLogo,
+        ClassName,
+        DartSourceCodeLocation,
+        EmptySpan,
+        ErrorSpan,
+        HorizontalAlign,
+        InlineData,
+        LogMessage,
+        LoggerName,
+        MethodName,
+        MultilineData,
+        NewLine,
+        PlainText,
+        SpanSequence,
+        StackTraceSpan,
+        Surrounded,
+        Timestamp,
+        Whitespace;

--- a/packages/chirp/lib/src/formatters/compact_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/compact_message_formatter.dart
@@ -1,4 +1,5 @@
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 
 /// Single-line compact format using spans.
 ///

--- a/packages/chirp/lib/src/formatters/rainbow_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/rainbow_message_formatter.dart
@@ -1,4 +1,5 @@
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 
 export 'package:chirp/src/span/span_foundation.dart';
 

--- a/packages/chirp/lib/src/formatters/simple_console_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/simple_console_message_formatter.dart
@@ -1,4 +1,5 @@
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 
 /// Simple, comprehensive text formatter that displays all LogRecord fields
 /// using the span-based templating system.

--- a/packages/chirp/lib/src/span/span_based_formatter.dart
+++ b/packages/chirp/lib/src/span/span_based_formatter.dart
@@ -1,4 +1,5 @@
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 import 'package:meta/meta.dart';
 
 /// Base class for formatters that use the span-based templating system.

--- a/packages/chirp/lib/src/span/spans.dart
+++ b/packages/chirp/lib/src/span/spans.dart
@@ -1,4 +1,5 @@
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 import 'package:chirp/src/formatters/yaml_formatter.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/chirp/test/simple_console_message_formatter_test.dart
+++ b/packages/chirp/test/simple_console_message_formatter_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/chirp/test/span_transformer_test.dart
+++ b/packages/chirp/test/span_transformer_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: avoid_redundant_argument_values
 
 import 'package:chirp/chirp.dart';
+import 'package:chirp/chirp_spans.dart';
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
Span-related exports are now available via a dedicated entry point:

```dart
import 'package:chirp/chirp_spans.dart';
```

This keeps the main `chirp.dart` import focused on the core logging API while providing a dedicated entry point for custom formatter development.

### Moved exports
- `SpanBasedFormatter`, `SpanFormatOptions`, `SpanTransformer`
- `LeafSpan`, `LogSpan`, `MultiChildSpan`, `SingleChildSpan`, `SlottedSpan`
- All built-in spans (`PlainText`, `AnsiStyled`, `Bordered`, etc.)
- `colorForHash`, `ColorSaturation` (hash-based coloring utilities)

### Usage
- **Standard logging**: `import 'package:chirp/chirp.dart';` - unchanged
- **Custom formatters**: `import 'package:chirp/chirp_spans.dart';` - new

## Test plan
- [x] All existing tests pass
- [x] Tests updated to import from correct locations
- [x] Example code updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)