### PR TITLE
Remove dimmed styling from log messages

### DIFF
--- a/packages/chirp/lib/src/formatters/rainbow_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/rainbow_message_formatter.dart
@@ -153,7 +153,7 @@ LogSpan _buildRainbowLogSpan({
   spans.addAll([
     Whitespace(),
     if (levelColor == null)
-      dimmed(LogMessage(record.message))
+      LogMessage(record.message)
     else
       AnsiStyled(
         foreground: levelColor,


### PR DESCRIPTION
Log messages for levels without a specific color (info, debug, verbose) were being dimmed, making them hard to read. Messages are now rendered with normal styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)