### PR TITLE
Allow lazy message construction in log methods

### DIFF
--- a/examples/simple/bin/lazy_messages.dart
+++ b/examples/simple/bin/lazy_messages.dart
@@ -8,9 +8,8 @@ import 'package:chirp/chirp.dart';
 void main() {
   // Configure logger with warning as minimum level.
   // trace and debug messages will be filtered out.
-  Chirp.root = ChirpLogger()
-    .setMinLogLevel(ChirpLogLevel.warning)
-    .addConsoleWriter();
+  Chirp.root =
+      ChirpLogger().setMinLogLevel(ChirpLogLevel.warning).addConsoleWriter();
 
   final hugeMap = {
     'users': List.generate(1000, (i) => {'id': i, 'name': 'User $i'}),

--- a/examples/simple/bin/lazy_messages.dart
+++ b/examples/simple/bin/lazy_messages.dart
@@ -1,0 +1,36 @@
+/// Example: Lazy message construction to avoid expensive string building.
+///
+/// Run with: dart run bin/lazy_messages.dart
+import 'dart:convert';
+
+import 'package:chirp/chirp.dart';
+
+void main() {
+  // Configure logger with warning as minimum level.
+  // trace and debug messages will be filtered out.
+  Chirp.root = ChirpLogger()
+    .setMinLogLevel(ChirpLogLevel.warning)
+    .addConsoleWriter();
+
+  final hugeMap = {
+    'users': List.generate(1000, (i) => {'id': i, 'name': 'User $i'}),
+  };
+
+  // Without lazy messages: jsonEncode() runs even though trace is filtered out
+  Chirp.trace('User data: ${jsonEncode(hugeMap)}');
+
+  // With lazy messages: the lambda is never called because trace is filtered
+  Chirp.trace(() => 'User data: ${jsonEncode(hugeMap)}');
+
+  // Works with all log levels
+  Chirp.warning(() => 'This warning is logged');
+  Chirp.error(() => 'This error is logged');
+
+  // Plain strings still work as before
+  Chirp.warning('Plain string warning');
+}
+
+// Output (only warning and above are shown):
+// ... [warning] This warning is logged
+// ... [error] This error is logged
+// ... [warning] Plain string warning

--- a/packages/chirp/CHANGELOG.md
+++ b/packages/chirp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **New** Lazy message construction — pass `() => 'expensive $message'` to any log method. The lambda is only called when the log level passes the filter, avoiding unnecessary string allocations.
+
 ## 0.8.0
 
 ### New Features

--- a/packages/chirp/README.md
+++ b/packages/chirp/README.md
@@ -907,6 +907,7 @@ See [`examples/simple/bin/`](https://github.com/passsy/chirp/tree/main/examples/
 | [`instance_tracking.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/instance_tracking.dart) | The `.chirp` extension |
 | [`multiple_writers.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/multiple_writers.dart) | Console + JSON output |
 | [`file_writer.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/file_writer.dart) | File logging with rotation |
+| [`lazy_messages.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/lazy_messages.dart) | Lazy message construction for performance |
 | [`interceptors.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/interceptors.dart) | Filtering and transforming logs |
 | [`library.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/library.dart) / [`app.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/app.dart) | Library logger adoption |
 | [`main.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/main.dart) | Span transformers (advanced) |

--- a/packages/chirp/README.md
+++ b/packages/chirp/README.md
@@ -467,6 +467,20 @@ Chirp.root = ChirpLogger().addConsoleWriter();
 Chirp.root.addWriter(myWriter);
 ```
 
+### Lazy Messages
+
+Pass a lambda instead of a string to defer expensive message construction. The lambda is only called when the log level passes the filter — avoiding unnecessary allocations when the logger is "off":
+
+```dart
+// Always builds the string, even if trace is filtered out
+logger.trace('User data: ${jsonEncode(hugeMap)}');
+
+// Lambda only called when trace level is active
+logger.trace(() => 'User data: ${jsonEncode(hugeMap)}');
+```
+
+This is especially useful for `trace` and `debug` messages that are typically disabled in production but contain expensive-to-build strings.
+
 ### Filtering
 
 Chirp provides two ways to filter logs:

--- a/packages/chirp/lib/src/core/chirp_logger.dart
+++ b/packages/chirp/lib/src/core/chirp_logger.dart
@@ -388,7 +388,11 @@ class ChirpLogger {
   /// methods, or when the level is determined dynamically.
   ///
   /// Parameters:
-  /// - [message]: The log message (can be any object, will be converted via `toString()`)
+  /// - [message]: The log message (can be any object, will be converted via
+  ///   `toString()`). Can also be a `Object? Function()` lambda for lazy
+  ///   evaluation — the lambda is only called when the message will actually
+  ///   be logged, avoiding expensive string construction when the log level
+  ///   is filtered out.
   /// - [level]: The severity level (defaults to [ChirpLogLevel.info])
   /// - [error]: Optional error object to log
   /// - [stackTrace]: Optional stack trace (often from a catch block)
@@ -423,11 +427,19 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    // Resolve lazy message after level check
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
+
     // Only capture caller if any writer needs it
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -471,10 +483,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -518,10 +536,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -565,10 +589,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       // ignore: avoid_redundant_argument_values
       level: level,
       error: error,
@@ -611,10 +641,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -658,10 +694,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -703,10 +745,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -750,10 +798,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -795,10 +849,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -841,10 +901,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,

--- a/packages/chirp/lib/src/core/chirp_logger.dart
+++ b/packages/chirp/lib/src/core/chirp_logger.dart
@@ -428,7 +428,7 @@ class ChirpLogger {
     if (min != null && level.severity < min.severity) return;
 
     // Resolve lazy message after level check
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -483,7 +483,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -536,7 +536,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -589,7 +589,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -641,7 +641,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -694,7 +694,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -745,7 +745,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -798,7 +798,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -849,7 +849,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {
@@ -901,7 +901,7 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
-    final resolvedMessage;
+    final Object? resolvedMessage;
     if (message is Object? Function()) {
       resolvedMessage = message();
     } else {

--- a/packages/chirp/test/chirp_logger_test.dart
+++ b/packages/chirp/test/chirp_logger_test.dart
@@ -1028,6 +1028,84 @@ void main() {
               'After adoption, only parent writers are used. Parent writer does not require caller info, so StackTrace.current should NOT be captured');
     });
   });
+
+  group('lazy message', () {
+    test('lambda is resolved when level passes', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()..addWriter(FakeWriter(records));
+
+      logger.info(() => 'lazy message');
+
+      expect(records, hasLength(1));
+      expect(records[0].message, 'lazy message');
+    });
+
+    test('lambda is not called when level is filtered out', () {
+      var callCount = 0;
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..setMinLogLevel(ChirpLogLevel.warning)
+        ..addWriter(FakeWriter(records));
+
+      logger.trace(() {
+        callCount++;
+        return 'expensive message';
+      });
+
+      expect(records, isEmpty);
+      expect(callCount, 0);
+    });
+
+    test('non-lambda message still works', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()..addWriter(FakeWriter(records));
+
+      logger.info('plain string');
+
+      expect(records, hasLength(1));
+      expect(records[0].message, 'plain string');
+    });
+
+    test('lambda works for all log levels', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..setMinLogLevel(ChirpLogLevel.trace)
+        ..addWriter(FakeWriter(records));
+
+      logger.log(() => 'log', level: ChirpLogLevel.info);
+      logger.trace(() => 'trace');
+      logger.debug(() => 'debug');
+      logger.info(() => 'info');
+      logger.notice(() => 'notice');
+      logger.success(() => 'success');
+      logger.warning(() => 'warning');
+      logger.error(() => 'error');
+      logger.critical(() => 'critical');
+      logger.wtf(() => 'wtf');
+
+      expect(records, hasLength(10));
+      expect(records[0].message, 'log');
+      expect(records[1].message, 'trace');
+      expect(records[2].message, 'debug');
+      expect(records[3].message, 'info');
+      expect(records[4].message, 'notice');
+      expect(records[5].message, 'success');
+      expect(records[6].message, 'warning');
+      expect(records[7].message, 'error');
+      expect(records[8].message, 'critical');
+      expect(records[9].message, 'wtf');
+    });
+
+    test('lambda returning null is stored as null', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()..addWriter(FakeWriter(records));
+
+      logger.info(() => null);
+
+      expect(records, hasLength(1));
+      expect(records[0].message, isNull);
+    });
+  });
 }
 
 /// Fake writer implementation for testing.

--- a/packages/chirp/test/chirp_logger_test.dart
+++ b/packages/chirp/test/chirp_logger_test.dart
@@ -1072,7 +1072,7 @@ void main() {
         ..setMinLogLevel(ChirpLogLevel.trace)
         ..addWriter(FakeWriter(records));
 
-      logger.log(() => 'log', level: ChirpLogLevel.info);
+      logger.log(() => 'log');
       logger.trace(() => 'trace');
       logger.debug(() => 'debug');
       logger.info(() => 'info');


### PR DESCRIPTION
Some log messages are expensive to construct (string interpolation, JSON serialization, etc.). When the logger's minimum level filters them out, the string is built for nothing.

All log methods (`log`, `trace`, `debug`, `info`, `notice`, `success`, `warning`, `error`, `critical`, `wtf`) now accept an `Object? Function()` lambda as the `message` parameter. The lambda is only called after the minLogLevel check passes:

```dart
// Before: always allocates, even when trace is filtered out
logger.trace('User data: ${jsonEncode(hugeMap)}');

// After: lambda only called when trace level is active
logger.trace(() => 'User data: ${jsonEncode(hugeMap)}');
```

No API changes — the `message` parameter is already `Object?`, which accepts `Function`. The resolution happens after the early level rejection, before creating the `LogRecord`. Plain strings continue to work exactly as before.