### PR TITLE
Add lazy log builders for every level

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         version: [
           # absolute minimum version, it is a breaking change when it doesn't work here anymore

--- a/examples/simple/bin/lazy_messages.dart
+++ b/examples/simple/bin/lazy_messages.dart
@@ -1,0 +1,35 @@
+/// Example: Lazy message construction to avoid expensive string building.
+///
+/// Run with: dart run bin/lazy_messages.dart
+import 'dart:convert';
+
+import 'package:chirp/chirp.dart';
+
+void main() {
+  // Configure logger with warning as minimum level.
+  // trace and debug messages will be filtered out.
+  Chirp.root =
+      ChirpLogger().setMinLogLevel(ChirpLogLevel.warning).addConsoleWriter();
+
+  final hugeMap = {
+    'users': List.generate(1000, (i) => {'id': i, 'name': 'User $i'}),
+  };
+
+  // Without lazy messages: jsonEncode() runs even though trace is filtered out
+  Chirp.trace('User data: ${jsonEncode(hugeMap)}');
+
+  // With lazy messages: the lambda is never called because trace is filtered
+  Chirp.trace(() => 'User data: ${jsonEncode(hugeMap)}');
+
+  // Works with all log levels
+  Chirp.warning(() => 'This warning is logged');
+  Chirp.error(() => 'This error is logged');
+
+  // Plain strings still work as before
+  Chirp.warning('Plain string warning');
+}
+
+// Output (only warning and above are shown):
+// ... [warning] This warning is logged
+// ... [error] This error is logged
+// ... [warning] Plain string warning

--- a/examples/simple/bin/lazy_messages.dart
+++ b/examples/simple/bin/lazy_messages.dart
@@ -1,4 +1,4 @@
-/// Example: Lazy message construction to avoid expensive string building.
+/// Example: Lazy message and lazy log construction.
 ///
 /// Run with: dart run bin/lazy_messages.dart
 import 'dart:convert';
@@ -15,21 +15,33 @@ void main() {
     'users': List.generate(1000, (i) => {'id': i, 'name': 'User $i'}),
   };
 
-  // Without lazy messages: jsonEncode() runs even though trace is filtered out
+  // Without lazy: jsonEncode() runs even though trace is filtered out.
   Chirp.trace('User data: ${jsonEncode(hugeMap)}');
 
-  // With lazy messages: the lambda is never called because trace is filtered
+  // Lazy message: the lambda is never called because trace is filtered.
   Chirp.trace(() => 'User data: ${jsonEncode(hugeMap)}');
 
-  // Works with all log levels
-  Chirp.warning(() => 'This warning is logged');
-  Chirp.error(() => 'This error is logged');
+  // traceLazy / warningLazy / etc.: defer EVERY argument (message, data,
+  // error, …) until the logger has decided to actually emit. Use this when
+  // expensive work is in the structured `data` map, not just the message.
+  Chirp.traceLazy(
+    (log) => log('User data', data: {'snapshot': jsonEncode(hugeMap)}),
+  );
+  Object().chirp.traceLazy((log) => log(() => 'asdf'));
 
-  // Plain strings still work as before
+  // Works at every level.
+  Chirp.warningLazy(
+    (log) => log('Rendered users', data: {'count': hugeMap.length}),
+  );
+  Chirp.errorLazy((log) => log('This error is logged'));
+
+  // Plain strings and lazy messages still work as before.
   Chirp.warning('Plain string warning');
+  Chirp.warning(() => 'Lazy string warning');
 }
 
 // Output (only warning and above are shown):
-// ... [warning] This warning is logged
+// ... [warning] Rendered users {count: 1}
 // ... [error] This error is logged
 // ... [warning] Plain string warning
+// ... [warning] Lazy string warning

--- a/packages/chirp/CHANGELOG.md
+++ b/packages/chirp/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- **New** Lazy message construction — pass `() => 'expensive $message'` to any log method. The lambda is only called when the log level passes the filter, avoiding unnecessary string allocations.
+
 ## 0.8.0
 
 ### New Features

--- a/packages/chirp/CHANGELOG.md
+++ b/packages/chirp/CHANGELOG.md
@@ -1,6 +1,17 @@
 ## Unreleased
 
-- **New** Lazy message construction — pass `() => 'expensive $message'` to any log method. The lambda is only called when the log level passes the filter, avoiding unnecessary string allocations.
+- **New** Lazy message construction — pass `() => 'expensive $message'` to any log method.
+  The lambda is only called when the log level passes the filter, avoiding unnecessary string allocations.
+- **New** Lazy log builders — `traceLazy`, `debugLazy`, `infoLazy`, `noticeLazy`, `successLazy`, `warningLazy`, `errorLazy`, `criticalLazy`, `wtfLazy`, and `logLazy` (with a `level:` argument) — defer the entire log call (message, `data`, `error`, `stackTrace`, `formatOptions`) until the level filter passes.
+  Useful when expensive work lives in the structured `data` map, not just the message string.
+  ```dart
+  Chirp.warningLazy(
+    (log) => log('snapshot', data: {'state': renderState()}),
+  );
+  ```
+  Matching `Chirp.*Lazy` static forwarders are exposed on the global logger.
+  Caller resolution lands on the `xxxLazy(...)` invocation line, not the inner `(log) => ...` lambda body, so eager and lazy calls report consistent source locations.
+  Adds the `ChirpLogFn` typedef for the inner `log` callback.
 
 ## 0.8.0
 

--- a/packages/chirp/README.md
+++ b/packages/chirp/README.md
@@ -467,6 +467,20 @@ Chirp.root = ChirpLogger().addConsoleWriter();
 Chirp.root.addWriter(myWriter);
 ```
 
+### Lazy Messages
+
+Pass a lambda instead of a string to defer expensive message construction. The lambda is only called when the log level passes the filter — avoiding unnecessary allocations when the logger is "off":
+
+```dart
+// Always builds the string, even if trace is filtered out
+logger.trace('User data: ${jsonEncode(hugeMap)}');
+
+// Lambda only called when trace level is active
+logger.trace(() => 'User data: ${jsonEncode(hugeMap)}');
+```
+
+This is especially useful for `trace` and `debug` messages that are typically disabled in production but contain expensive-to-build strings.
+
 ### Filtering
 
 Chirp provides two ways to filter logs:
@@ -893,6 +907,7 @@ See [`examples/simple/bin/`](https://github.com/passsy/chirp/tree/main/examples/
 | [`instance_tracking.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/instance_tracking.dart) | The `.chirp` extension |
 | [`multiple_writers.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/multiple_writers.dart) | Console + JSON output |
 | [`file_writer.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/file_writer.dart) | File logging with rotation |
+| [`lazy_messages.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/lazy_messages.dart) | Lazy message construction for performance |
 | [`interceptors.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/interceptors.dart) | Filtering and transforming logs |
 | [`library.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/library.dart) / [`app.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/app.dart) | Library logger adoption |
 | [`main.dart`](https://github.com/passsy/chirp/blob/main/examples/simple/bin/main.dart) | Span transformers (advanced) |

--- a/packages/chirp/README.md
+++ b/packages/chirp/README.md
@@ -467,9 +467,15 @@ Chirp.root = ChirpLogger().addConsoleWriter();
 Chirp.root.addWriter(myWriter);
 ```
 
-### Lazy Messages
+### Lazy Logging
 
-Pass a lambda instead of a string to defer expensive message construction. The lambda is only called when the log level passes the filter — avoiding unnecessary allocations when the logger is "off":
+Defer expensive log construction until the logger has decided to actually emit.
+Two flavors, picked by what's expensive.
+
+#### Lazy Messages
+
+Pass a lambda instead of a string to defer expensive message construction.
+The lambda is only called when the log level passes the filter — avoiding unnecessary allocations when the logger is "off":
 
 ```dart
 // Always builds the string, even if trace is filtered out
@@ -480,6 +486,36 @@ logger.trace(() => 'User data: ${jsonEncode(hugeMap)}');
 ```
 
 This is especially useful for `trace` and `debug` messages that are typically disabled in production but contain expensive-to-build strings.
+
+#### Lazy Builders
+
+When the expensive work lives in `data`, `error`, `stackTrace`, or any other named argument — not just the message — use the `xxxLazy` variant.
+The builder is invoked only when the level passes, so every argument it constructs is paid for only on records that will actually be emitted.
+
+```dart
+// Defers EVERY argument (message, data, error, ...) until the logger emits
+Chirp.warningLazy(
+  (log) => log('snapshot', data: {'state': renderState(), 'metrics': dump()}),
+);
+
+// Works for every level
+Chirp.errorLazy((log) => log('failed', error: e, stackTrace: st));
+
+// logLazy takes a level: argument
+Chirp.logLazy(
+  (log) => log('msg', data: {'state': render()}),
+  level: ChirpLogLevel.debug,
+);
+```
+
+The inner `log` callback has the same shape as the eager method (typedef `ChirpLogFn`), so call sites read identically — minus the wasted work when the log will be discarded.
+
+Caller resolution is handled automatically: the `xxxLazy(...)` invocation line is reported, not the inner `(log) => ...` lambda body, so source locations look the same whether the call is eager or lazy.
+
+Available variants: `traceLazy`, `debugLazy`, `infoLazy`, `noticeLazy`, `successLazy`, `warningLazy`, `errorLazy`, `criticalLazy`, `wtfLazy`, plus the generic `logLazy` on both `ChirpLogger` instances and the global `Chirp` static API.
+
+Lazy builders cost one closure allocation per call when the level passes; the level-filtered hot path stays as cheap as the eager methods.
+Reach for `xxxLazy` when constructing `data` (or other arguments) is expensive; reach for the lazy-message form when only the message is.
 
 ### Filtering
 

--- a/packages/chirp/lib/chirp.dart
+++ b/packages/chirp/lib/chirp.dart
@@ -31,7 +31,7 @@ export 'package:chirp/src/ansi/console_color.dart'
 export 'package:chirp/src/core/chirp_formatter.dart'
     show ChirpFormatter, MessageBuffer;
 export 'package:chirp/src/core/chirp_interceptor.dart' show ChirpInterceptor;
-export 'package:chirp/src/core/chirp_logger.dart' show ChirpLogger;
+export 'package:chirp/src/core/chirp_logger.dart' show ChirpLogFn, ChirpLogger;
 export 'package:chirp/src/core/chirp_root.dart'
     show Chirp, ChirpInstanceLogger, ChirpLoggerConsoleWriterExt, LogRecordExt;
 export 'package:chirp/src/core/chirp_writer.dart' show ChirpWriter;

--- a/packages/chirp/lib/src/core/chirp_logger.dart
+++ b/packages/chirp/lib/src/core/chirp_logger.dart
@@ -388,7 +388,11 @@ class ChirpLogger {
   /// methods, or when the level is determined dynamically.
   ///
   /// Parameters:
-  /// - [message]: The log message (can be any object, will be converted via `toString()`)
+  /// - [message]: The log message (can be any object, will be converted via
+  ///   `toString()`). Can also be a `Object? Function()` lambda for lazy
+  ///   evaluation — the lambda is only called when the message will actually
+  ///   be logged, avoiding expensive string construction when the log level
+  ///   is filtered out.
   /// - [level]: The severity level (defaults to [ChirpLogLevel.info])
   /// - [error]: Optional error object to log
   /// - [stackTrace]: Optional stack trace (often from a catch block)
@@ -423,11 +427,19 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    // Resolve lazy message after level check
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
+
     // Only capture caller if any writer needs it
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -471,10 +483,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -518,10 +536,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -565,10 +589,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       // ignore: avoid_redundant_argument_values
       level: level,
       error: error,
@@ -611,10 +641,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -658,10 +694,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -703,10 +745,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -750,10 +798,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -795,10 +849,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,
@@ -841,10 +901,16 @@ class ChirpLogger {
     final min = _effectiveMinLogLevel;
     if (min != null && level.severity < min.severity) return;
 
+    final Object? resolvedMessage;
+    if (message is Object? Function()) {
+      resolvedMessage = message();
+    } else {
+      resolvedMessage = message;
+    }
     final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
 
     final entry = LogRecord(
-      message: message,
+      message: resolvedMessage,
       level: level,
       error: error,
       stackTrace: stackTrace,

--- a/packages/chirp/lib/src/core/chirp_logger.dart
+++ b/packages/chirp/lib/src/core/chirp_logger.dart
@@ -8,6 +8,26 @@ import 'package:chirp/src/core/log_level.dart';
 import 'package:chirp/src/core/log_record.dart';
 import 'package:clock/clock.dart';
 
+/// Signature of the inner `log` callback passed to a lazy log builder.
+///
+/// Mirrors the named arguments of the level methods ([ChirpLogger.trace],
+/// [ChirpLogger.info], etc.) so that a lazy log call reads identically to the
+/// eager form:
+///
+/// ```dart
+/// // eager
+/// logger.trace('msg', data: {/* expensive */});
+/// // lazy — body only runs when the level passes the filter
+/// logger.traceLazy((log) => log('msg', data: {/* expensive */}));
+/// ```
+typedef ChirpLogFn = void Function(
+  Object? message, {
+  Object? error,
+  StackTrace? stackTrace,
+  Map<String, Object?>? data,
+  List<FormatOptions>? formatOptions,
+});
+
 /// Flexible logger class supporting named loggers, child loggers, and custom writers.
 ///
 /// [ChirpLogger] provides instance methods for logging at different severity
@@ -925,6 +945,147 @@ class ChirpLogger {
     );
 
     _logRecord(entry);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Lazy variants
+  //
+  // Each `xxxLazy` method below mirrors its eager counterpart but only invokes
+  // the supplied builder when the level passes the [minLogLevel] filter. The
+  // builder receives a [ChirpLogFn] that takes the same named arguments as the
+  // eager method, so call sites read identically — minus the wasted work when
+  // the log will be discarded.
+  //
+  // Unlike the eager methods (which inline LogRecord construction to keep the
+  // filtered-out hot path cheap), the lazy methods share a single
+  // [_lazyLogFn] helper. The level filter still runs in each method, so the
+  // helper is only reached for records that will actually be emitted.
+  // ---------------------------------------------------------------------------
+
+  /// Lazy variant of [log]. The [builder] is invoked only when [level] passes
+  /// the effective minimum log level. Use this when constructing the message
+  /// or `data` map is expensive.
+  ///
+  /// ```dart
+  /// logger.logLazy(
+  ///   (log) => log('snapshot', data: {'state': renderState()}),
+  ///   level: ChirpLogLevel.debug,
+  /// );
+  /// ```
+  void logLazy(
+    void Function(ChirpLogFn log) builder, {
+    ChirpLogLevel level = ChirpLogLevel.info,
+    int? skipFrames,
+  }) {
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level, skipFrames: skipFrames));
+  }
+
+  /// Lazy variant of [trace]. See [logLazy] for usage.
+  void traceLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.trace;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [debug]. See [logLazy] for usage.
+  void debugLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.debug;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [info]. See [logLazy] for usage.
+  void infoLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.info;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [notice]. See [logLazy] for usage.
+  void noticeLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.notice;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [success]. See [logLazy] for usage.
+  void successLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.success;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [warning]. See [logLazy] for usage.
+  void warningLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.warning;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [error]. See [logLazy] for usage.
+  void errorLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.error;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [critical]. See [logLazy] for usage.
+  void criticalLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.critical;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Lazy variant of [wtf]. See [logLazy] for usage.
+  void wtfLazy(void Function(ChirpLogFn log) builder) {
+    const level = ChirpLogLevel.wtf;
+    final min = _effectiveMinLogLevel;
+    if (min != null && level.severity < min.severity) return;
+    builder(_lazyLogFn(level));
+  }
+
+  /// Builds the [ChirpLogFn] handed to a lazy builder. Reached only after the
+  /// level filter has passed, so the closure cost lands on records that will
+  /// actually be emitted.
+  ChirpLogFn _lazyLogFn(ChirpLogLevel level, {int? skipFrames}) {
+    // +1 skips the user's `(log) => log(...)` frame so caller resolution
+    // matches the eager methods.
+    final lazySkipFrames = (skipFrames ?? 0) + 1;
+    return (message, {error, stackTrace, data, formatOptions}) {
+      final Object? resolvedMessage;
+      if (message is Object? Function()) {
+        resolvedMessage = message();
+      } else {
+        resolvedMessage = message;
+      }
+      final caller = _effectiveRequiresCallerInfo ? StackTrace.current : null;
+      final entry = LogRecord(
+        message: resolvedMessage,
+        level: level,
+        error: error,
+        stackTrace: stackTrace,
+        caller: caller,
+        skipFrames: lazySkipFrames,
+        timestamp: clock.now(),
+        wallClock: DateTime.now(),
+        zone: Zone.current,
+        loggerName: name,
+        instance: instance,
+        data: _mergeData(_effectiveContext, data),
+        formatOptions: formatOptions,
+      );
+      _logRecord(entry);
+    };
   }
 
   /// Writes a log record to all configured writers.

--- a/packages/chirp/lib/src/core/chirp_root.dart
+++ b/packages/chirp/lib/src/core/chirp_root.dart
@@ -250,6 +250,51 @@ class Chirp {
       formatOptions: formatOptions,
     );
   }
+
+  /// Lazy variant of [log] — see [ChirpLogger.logLazy].
+  static void logLazy(
+    void Function(ChirpLogFn log) builder, {
+    ChirpLogLevel level = ChirpLogLevel.info,
+    int? skipFrames,
+  }) =>
+      _effectiveRootLogger.logLazy(builder,
+          level: level, skipFrames: skipFrames);
+
+  /// Lazy variant of [trace] — see [ChirpLogger.traceLazy].
+  static void traceLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.traceLazy(builder);
+
+  /// Lazy variant of [debug] — see [ChirpLogger.debugLazy].
+  static void debugLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.debugLazy(builder);
+
+  /// Lazy variant of [info] — see [ChirpLogger.infoLazy].
+  static void infoLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.infoLazy(builder);
+
+  /// Lazy variant of [notice] — see [ChirpLogger.noticeLazy].
+  static void noticeLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.noticeLazy(builder);
+
+  /// Lazy variant of [success] — see [ChirpLogger.successLazy].
+  static void successLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.successLazy(builder);
+
+  /// Lazy variant of [warning] — see [ChirpLogger.warningLazy].
+  static void warningLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.warningLazy(builder);
+
+  /// Lazy variant of [error] — see [ChirpLogger.errorLazy].
+  static void errorLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.errorLazy(builder);
+
+  /// Lazy variant of [critical] — see [ChirpLogger.criticalLazy].
+  static void criticalLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.criticalLazy(builder);
+
+  /// Lazy variant of [wtf] — see [ChirpLogger.wtfLazy].
+  static void wtfLazy(void Function(ChirpLogFn log) builder) =>
+      _effectiveRootLogger.wtfLazy(builder);
 }
 
 /// Extension on [ChirpLogger] to add convenience methods for console writers.

--- a/packages/chirp/test/chirp_logger_test.dart
+++ b/packages/chirp/test/chirp_logger_test.dart
@@ -1248,7 +1248,8 @@ void main() {
       final info = records[0].callerInfo;
       expect(info, isNotNull);
       expect(info!.file, contains('chirp_logger_test.dart'),
-          reason: 'caller should resolve to the test file, not chirp internals');
+          reason:
+              'caller should resolve to the test file, not chirp internals');
     });
 
     test(

--- a/packages/chirp/test/chirp_logger_test.dart
+++ b/packages/chirp/test/chirp_logger_test.dart
@@ -1106,6 +1106,229 @@ void main() {
       expect(records[0].message, isNull);
     });
   });
+
+  group('xxxLazy', () {
+    test('builder is invoked when level passes and forwards all args', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()..addWriter(FakeWriter(records));
+
+      logger.warningLazy(
+        (log) => log('oops', data: {'k': 'v'}, error: 'err'),
+      );
+
+      expect(records, hasLength(1));
+      expect(records[0].message, 'oops');
+      expect(records[0].level, ChirpLogLevel.warning);
+      expect(records[0].data, {'k': 'v'});
+      expect(records[0].error, 'err');
+    });
+
+    test('builder is not invoked when level is filtered out', () {
+      var callCount = 0;
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..setMinLogLevel(ChirpLogLevel.warning)
+        ..addWriter(FakeWriter(records));
+
+      logger.traceLazy((log) {
+        callCount++;
+        log('expensive', data: {'big': 'payload'});
+      });
+
+      expect(records, isEmpty);
+      expect(callCount, 0);
+    });
+
+    test('lazy variants exist for every level', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..setMinLogLevel(ChirpLogLevel.trace)
+        ..addWriter(FakeWriter(records));
+
+      logger.logLazy((log) => log('log'));
+      logger.traceLazy((log) => log('trace'));
+      logger.debugLazy((log) => log('debug'));
+      logger.infoLazy((log) => log('info'));
+      logger.noticeLazy((log) => log('notice'));
+      logger.successLazy((log) => log('success'));
+      logger.warningLazy((log) => log('warning'));
+      logger.errorLazy((log) => log('error'));
+      logger.criticalLazy((log) => log('critical'));
+      logger.wtfLazy((log) => log('wtf'));
+
+      expect(records.map((r) => r.message), [
+        'log',
+        'trace',
+        'debug',
+        'info',
+        'notice',
+        'success',
+        'warning',
+        'error',
+        'critical',
+        'wtf',
+      ]);
+    });
+
+    test('logLazy respects the level: argument', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()..addWriter(FakeWriter(records));
+
+      logger.logLazy(
+        (log) => log('boom'),
+        level: ChirpLogLevel.error,
+      );
+
+      expect(records, hasLength(1));
+      expect(records[0].level, ChirpLogLevel.error);
+      expect(records[0].message, 'boom');
+    });
+
+    test('logLazy filters by level before invoking the builder', () {
+      var callCount = 0;
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..setMinLogLevel(ChirpLogLevel.error)
+        ..addWriter(FakeWriter(records));
+
+      logger.logLazy(
+        (log) {
+          callCount++;
+          log('should not run');
+        },
+        level: ChirpLogLevel.debug,
+      );
+
+      expect(records, isEmpty);
+      expect(callCount, 0);
+    });
+
+    test('builder callback message can itself be a lambda', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()..addWriter(FakeWriter(records));
+
+      logger.infoLazy((log) => log(() => 'nested lazy'));
+
+      expect(records, hasLength(1));
+      expect(records[0].message, 'nested lazy');
+    });
+
+    test('logger context is merged into lazy log data', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger(context: {'requestId': 'r-1'})
+        ..addWriter(FakeWriter(records));
+
+      logger.infoLazy((log) => log('msg', data: {'extra': 'x'}));
+
+      expect(records, hasLength(1));
+      expect(records[0].data, {'requestId': 'r-1', 'extra': 'x'});
+    });
+  });
+
+  group('xxxLazy caller resolution', () {
+    test('caller is captured when a writer requires it', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..addWriter(FakeWriterRequiringCallerInfo(records));
+
+      logger.traceLazy((log) => log('msg'));
+
+      expect(records, hasLength(1));
+      expect(records[0].caller, isNotNull);
+      expect(records[0].caller.toString(), contains('chirp_logger_test.dart'));
+    });
+
+    test('caller resolves to the user file, not chirp internals', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..addWriter(FakeWriterRequiringCallerInfo(records));
+
+      logger.traceLazy((log) => log('msg'));
+
+      final info = records[0].callerInfo;
+      expect(info, isNotNull);
+      expect(info!.file, contains('chirp_logger_test.dart'),
+          reason: 'caller should resolve to the test file, not chirp internals');
+    });
+
+    test(
+        'multi-line lazy call reports the invocation line, not the lambda body',
+        () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..addWriter(FakeWriterRequiringCallerInfo(records));
+
+      // Adjacent eager and lazy calls. The lazy call spans 3 lines but its
+      // resolved caller line should equal `eagerLine + 1` — i.e. the
+      // `traceLazy(` invocation, not the `(log) => log(...)` body that lives
+      // one line below.
+      logger.trace('eager');
+      logger.traceLazy(
+        (log) => log('lazy'),
+      );
+
+      final eagerLine = records[0].callerInfo!.line;
+      final lazyLine = records[1].callerInfo!.line;
+      expect(
+        lazyLine - eagerLine,
+        1,
+        reason: 'Got eagerLine=$eagerLine lazyLine=$lazyLine. The lazy call '
+            'site is one line below the eager call. Caller should resolve to '
+            'the .traceLazy() invocation, not the inner lambda body.',
+      );
+    });
+
+    test('lazy and eager report adjacent lines when on adjacent single lines',
+        () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..addWriter(FakeWriterRequiringCallerInfo(records));
+
+      logger.trace('eager');
+      logger.traceLazy((log) => log('lazy'));
+
+      final eagerLine = records[0].callerInfo!.line;
+      final lazyLine = records[1].callerInfo!.line;
+      expect(lazyLine, eagerLine + 1);
+    });
+
+    test('logLazy skipFrames composes with the internal lambda absorption', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..addWriter(FakeWriterRequiringCallerInfo(records));
+
+      // Wrappers that themselves call into the logger. With skipFrames: 1 the
+      // caller should resolve past the wrapper to its own caller — the test
+      // body — for both eager and lazy paths.
+      void eagerWrapper(String msg) => logger.log(msg, skipFrames: 1);
+      void lazyWrapper(String msg) =>
+          logger.logLazy((log) => log(msg), skipFrames: 1);
+
+      eagerWrapper('eager');
+      lazyWrapper('lazy');
+
+      final eagerLine = records[0].callerInfo!.line;
+      final lazyLine = records[1].callerInfo!.line;
+      expect(
+        lazyLine - eagerLine,
+        1,
+        reason: 'Got eagerLine=$eagerLine lazyLine=$lazyLine. With '
+            'skipFrames: 1 both should resolve through the wrapper to the '
+            'two adjacent test-body lines.',
+      );
+    });
+
+    test('logLazy without explicit skipFrames resolves to user code', () {
+      final records = <LogRecord>[];
+      final logger = ChirpLogger()
+        ..addWriter(FakeWriterRequiringCallerInfo(records));
+
+      logger.logLazy((log) => log('msg'), level: ChirpLogLevel.warning);
+
+      expect(records[0].callerInfo, isNotNull);
+      expect(records[0].callerInfo!.file, contains('chirp_logger_test.dart'));
+    });
+  });
 }
 
 /// Fake writer implementation for testing.

--- a/packages/chirp/test/fake_async_with_drain.dart
+++ b/packages/chirp/test/fake_async_with_drain.dart
@@ -78,7 +78,10 @@ extension on FakeAsync {
   /// complete (e.g. writeFrom → flush → close, where each completion
   /// triggers the next operation).
   Future<void> settleIo() async {
-    for (var i = 0; i < 3; i++) {
+    // Chained async I/O (writeFrom → .whenComplete → flush → close) needs
+    // multiple event-loop yields to fully settle. 10 rounds handles deep
+    // chains reliably, even on slow CI containers.
+    for (var i = 0; i < 10; i++) {
       await Future<void>.delayed(const Duration(milliseconds: 1));
       run((_) => flushMicrotasks());
     }

--- a/packages/chirp/test/rotating_file_writer_test.dart
+++ b/packages/chirp/test/rotating_file_writer_test.dart
@@ -358,7 +358,8 @@ void main() {
       });
     });
 
-    test('lazy baseFilePathProvider drains buffer after flushInterval', () async {
+    test('lazy baseFilePathProvider drains buffer after flushInterval',
+        () async {
       await fakeAsyncWithDrain((async) async {
         final tempDir = createTempDir();
         final logPath = '${tempDir.path}/lazy-buffered/app.log';

--- a/packages/chirp/test/rotating_file_writer_test.dart
+++ b/packages/chirp/test/rotating_file_writer_test.dart
@@ -358,8 +358,8 @@ void main() {
       });
     });
 
-    test('lazy baseFilePathProvider drains buffer after flushInterval', () {
-      fakeAsync((async) {
+    test('lazy baseFilePathProvider drains buffer after flushInterval', () async {
+      await fakeAsyncWithDrain((async) async {
         final tempDir = createTempDir();
         final logPath = '${tempDir.path}/lazy-buffered/app.log';
 
@@ -389,15 +389,16 @@ void main() {
               '(flushInterval is 10s)',
         );
 
-        // Advance past the flushInterval.
+        // Advance past the flushInterval — fires the flush timer which
+        // starts real async file I/O.
         async.elapse(const Duration(seconds: 2));
-        async.flushMicrotasks();
+        await drainEvent();
 
         final content = File(logPath).readAsStringSync();
         expect(content, contains('Buffered info'));
 
         writer.close();
-        async.flushMicrotasks();
+        await drainEvent();
       });
     });
 


### PR DESCRIPTION
Lazy messages defer the message string, but everything else on the call (the `data` map, `error`, `stackTrace`, `formatOptions`) still runs eagerly.
The new `xxxLazy` variants take a builder that receives a `ChirpLogFn` matching the eager method's named arguments, so the *whole* call is paid for only on records that actually emit.

```dart
// Lazy message — defers the string only
Chirp.trace(() => 'User: ${jsonEncode(hugeMap)}');

// Lazy builder — defers everything
Chirp.warningLazy(
  (log) => log('snapshot', data: {'state': renderState(), 'metrics': dump()}),
);

Chirp.errorLazy((log) => log('failed', error: e, stackTrace: st));

Chirp.logLazy(
  (log) => log('msg', data: {'state': render()}),
  level: ChirpLogLevel.debug,
);
```

### What's added

- `ChirpLogger.logLazy`, `traceLazy`, `debugLazy`, `infoLazy`, `noticeLazy`, `successLazy`, `warningLazy`, `errorLazy`, `criticalLazy`, `wtfLazy`
- Matching `Chirp.*Lazy` static forwarders
- `ChirpLogFn` typedef for the inner `log` callback

### Implementation notes

- The level filter still runs inline in each `xxxLazy` method — the filtered-out hot path is as cheap as the eager methods (no extra method call, no extra frame).
- `LogRecord` construction is shared via `_lazyLogFn`, only reached after the level passes. Closure allocation lands only on records that will actually be emitted.
- `_lazyLogFn` bumps `skipFrames` by one so caller resolution lands on the user's `xxxLazy(...)` invocation line, not the inner `(log) => ...` lambda body — eager and lazy report consistent source locations. Tested in `xxxLazy caller resolution`.

### Why a separate method instead of `lazy:` named parameter

Earlier draft used `Chirp.trace(null, lazy: (log) => log(...))`.
The required `null` positional was ugly and the `lazy` parameter typed the closure as `dynamic` (no autocomplete, typos in `data:` slipped through).
Separate methods give a fully typed `ChirpLogFn` parameter — autocomplete works, and the `null` goes away.
