### PR TITLE
Stabilize buffered file writer tests

### DIFF
--- a/packages/chirp/test/rotating_file_writer_test.dart
+++ b/packages/chirp/test/rotating_file_writer_test.dart
@@ -13,6 +13,7 @@ import 'package:test/test.dart';
 
 import 'fake_async_with_drain.dart';
 import 'test_log_record.dart';
+import 'tracking_io_overrides.dart';
 
 void main() {
   group('SimpleFileFormatter', () {
@@ -1664,39 +1665,46 @@ void main() {
     });
 
     test('timer resets after flush, next write starts new timer', () async {
-      await fakeAsyncWithDrain((async) async {
-        final tempDir = createTempDir();
-        final logPath = '${tempDir.path}/app.log';
-        final writer = RotatingFileWriter(
-          baseFilePathProvider: () => logPath,
-          flushStrategy: FlushStrategy.buffered,
-        );
+      final io = TrackingIoOverrides();
+      await io.run(() async {
+        await fakeAsyncWithDrain((async) async {
+          final tempDir = createTempDir();
+          final logPath = '${tempDir.path}/app.log';
+          final writer = RotatingFileWriter(
+            baseFilePathProvider: () => logPath,
+            flushStrategy: FlushStrategy.buffered,
+          );
 
-        // First batch
-        writer.write(testRecord(message: 'Batch 1'));
-        async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+          // First batch
+          writer.write(testRecord(message: 'Batch 1'));
+          final firstFlush = io.trapFlush();
+          async.elapse(const Duration(seconds: 1));
+          await firstFlush.wait();
+          async.flushMicrotasks();
 
-        final content = File(logPath).readAsStringSync();
-        expect(content, contains('Batch 1'));
-        expect(content, isNot(contains('Batch 2')));
+          final content = File(logPath).readAsStringSync();
+          expect(content, contains('Batch 1'));
+          expect(content, isNot(contains('Batch 2')));
 
-        // Second batch - starts new timer
-        writer.write(testRecord(message: 'Batch 2'));
+          // Second batch - starts new timer
+          writer.write(testRecord(message: 'Batch 2'));
 
-        // Immediately, batch 2 not flushed yet
-        expect(File(logPath).readAsStringSync(), isNot(contains('Batch 2')),
-            reason: 'Batch 2 not yet flushed');
+          // Immediately, batch 2 not flushed yet
+          expect(File(logPath).readAsStringSync(), isNot(contains('Batch 2')),
+              reason: 'Batch 2 not yet flushed');
 
-        async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+          final secondFlush = io.trapFlush();
+          async.elapse(const Duration(seconds: 1));
+          await secondFlush.wait();
+          async.flushMicrotasks();
 
-        final content2 = File(logPath).readAsStringSync();
-        expect(content2, contains('Batch 1'));
-        expect(content2, contains('Batch 2'));
+          final content2 = File(logPath).readAsStringSync();
+          expect(content2, contains('Batch 1'));
+          expect(content2, contains('Batch 2'));
 
-        await writer.close();
-        await drainEvent();
+          await writer.close();
+          await drainEvent();
+        });
       });
     });
 
@@ -1891,50 +1899,59 @@ void main() {
     });
 
     test('sustained logging: each flush resets timer for next batch', () async {
-      await fakeAsyncWithDrain((async) async {
-        final tempDir = createTempDir();
-        final logPath = '${tempDir.path}/app.log';
-        final writer = RotatingFileWriter(
-          baseFilePathProvider: () => logPath,
-          flushStrategy: FlushStrategy.buffered,
-        );
+      final io = TrackingIoOverrides();
+      await io.run(() async {
+        await fakeAsyncWithDrain((async) async {
+          final tempDir = createTempDir();
+          final logPath = '${tempDir.path}/app.log';
+          final writer = RotatingFileWriter(
+            baseFilePathProvider: () => logPath,
+            flushStrategy: FlushStrategy.buffered,
+          );
 
-        // Batch 1
-        writer.write(testRecord(message: 'Batch 1 - Msg 1'));
-        writer.write(testRecord(message: 'Batch 1 - Msg 2'));
-        async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+          // Batch 1
+          writer.write(testRecord(message: 'Batch 1 - Msg 1'));
+          writer.write(testRecord(message: 'Batch 1 - Msg 2'));
+          final firstFlush = io.trapFlush();
+          async.elapse(const Duration(seconds: 1));
+          await firstFlush.wait();
+          async.flushMicrotasks();
 
-        var content = File(logPath).readAsStringSync();
-        expect(content, contains('Batch 1 - Msg 1'));
-        expect(content, contains('Batch 1 - Msg 2'));
+          var content = File(logPath).readAsStringSync();
+          expect(content, contains('Batch 1 - Msg 1'));
+          expect(content, contains('Batch 1 - Msg 2'));
 
-        // Batch 2
-        writer.write(testRecord(message: 'Batch 2 - Msg 1'));
-        async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+          // Batch 2
+          writer.write(testRecord(message: 'Batch 2 - Msg 1'));
+          final secondFlush = io.trapFlush();
+          async.elapse(const Duration(seconds: 1));
+          await secondFlush.wait();
+          async.flushMicrotasks();
 
-        content = File(logPath).readAsStringSync();
-        expect(content, contains('Batch 2 - Msg 1'));
+          content = File(logPath).readAsStringSync();
+          expect(content, contains('Batch 2 - Msg 1'));
 
-        // Batch 3
-        writer.write(testRecord(message: 'Batch 3 - Msg 1'));
-        writer.write(testRecord(message: 'Batch 3 - Msg 2'));
-        writer.write(testRecord(message: 'Batch 3 - Msg 3'));
-        async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+          // Batch 3
+          writer.write(testRecord(message: 'Batch 3 - Msg 1'));
+          writer.write(testRecord(message: 'Batch 3 - Msg 2'));
+          writer.write(testRecord(message: 'Batch 3 - Msg 3'));
+          final thirdFlush = io.trapFlush();
+          async.elapse(const Duration(seconds: 1));
+          await thirdFlush.wait();
+          async.flushMicrotasks();
 
-        // All batches flushed
-        content = File(logPath).readAsStringSync();
-        expect(content, contains('Batch 1 - Msg 1'));
-        expect(content, contains('Batch 1 - Msg 2'));
-        expect(content, contains('Batch 2 - Msg 1'));
-        expect(content, contains('Batch 3 - Msg 1'));
-        expect(content, contains('Batch 3 - Msg 2'));
-        expect(content, contains('Batch 3 - Msg 3'));
+          // All batches flushed
+          content = File(logPath).readAsStringSync();
+          expect(content, contains('Batch 1 - Msg 1'));
+          expect(content, contains('Batch 1 - Msg 2'));
+          expect(content, contains('Batch 2 - Msg 1'));
+          expect(content, contains('Batch 3 - Msg 1'));
+          expect(content, contains('Batch 3 - Msg 2'));
+          expect(content, contains('Batch 3 - Msg 3'));
 
-        await writer.close();
-        await drainEvent();
+          await writer.close();
+          await drainEvent();
+        });
       });
     });
 

--- a/packages/chirp/test/tracking_io_overrides.dart
+++ b/packages/chirp/test/tracking_io_overrides.dart
@@ -1,0 +1,320 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+/// Tracks file I/O created through [File] while delegating to the real file
+/// system.
+final class TrackingIoOverrides extends IOOverrides {
+  int _completedFlushes = 0;
+  final List<_FlushWaiter> _flushWaiters = [];
+
+  Future<T> run<T>(Future<T> Function() body) {
+    return IOOverrides.runWithIOOverrides(body, this);
+  }
+
+  TrackingIoTrap trapFlush() {
+    return TrackingIoTrap._(
+      overrides: this,
+      completedFlushesAtCreation: _completedFlushes,
+    );
+  }
+
+  @override
+  File createFile(String path) {
+    final file = super.createFile(path);
+    return _TrackingFile(file, this);
+  }
+
+  void _trackFlush(Future<RandomAccessFile> flush) {
+    flush.whenComplete(() {
+      _completedFlushes++;
+      _completeReadyFlushWaiters();
+    });
+  }
+
+  Future<void> _waitForFlushAfter(int completedFlushes) {
+    if (_completedFlushes > completedFlushes) {
+      return Future<void>.value();
+    }
+
+    final waiter = _FlushWaiter(completedFlushes);
+    _flushWaiters.add(waiter);
+    return waiter.future;
+  }
+
+  void _completeReadyFlushWaiters() {
+    final ready = _flushWaiters.where((it) {
+      return _completedFlushes > it.completedFlushesAtCreation;
+    }).toList();
+
+    _flushWaiters.removeWhere(ready.contains);
+
+    for (final waiter in ready) {
+      waiter.complete();
+    }
+  }
+}
+
+final class TrackingIoTrap {
+  TrackingIoTrap._({
+    required TrackingIoOverrides overrides,
+    required int completedFlushesAtCreation,
+  })  : _overrides = overrides,
+        _completedFlushesAtCreation = completedFlushesAtCreation;
+
+  final TrackingIoOverrides _overrides;
+  final int _completedFlushesAtCreation;
+
+  Future<void> wait({
+    Duration timeout = const Duration(seconds: 5),
+  }) {
+    return _overrides
+        ._waitForFlushAfter(_completedFlushesAtCreation)
+        .timeout(timeout);
+  }
+}
+
+final class _FlushWaiter {
+  _FlushWaiter(this.completedFlushesAtCreation);
+
+  final int completedFlushesAtCreation;
+  final Completer<void> _completer = Completer<void>();
+
+  Future<void> get future => _completer.future;
+
+  void complete() {
+    if (_completer.isCompleted) {
+      return;
+    }
+    _completer.complete();
+  }
+}
+
+final class _TrackingFile implements File {
+  _TrackingFile(this._file, this._overrides);
+
+  final File _file;
+  final TrackingIoOverrides _overrides;
+
+  @override
+  String get path => _file.path;
+
+  @override
+  Directory get parent => _file.parent;
+
+  @override
+  Uri get uri => _file.uri;
+
+  @override
+  File get absolute => _TrackingFile(_file.absolute, _overrides);
+
+  @override
+  bool existsSync() {
+    return _file.existsSync();
+  }
+
+  @override
+  Future<bool> exists() {
+    return _file.exists();
+  }
+
+  @override
+  int lengthSync() {
+    return _file.lengthSync();
+  }
+
+  @override
+  Future<int> length() {
+    return _file.length();
+  }
+
+  @override
+  RandomAccessFile openSync({
+    FileMode mode = FileMode.read,
+  }) {
+    final file = _file.openSync(mode: mode);
+    return _TrackingRandomAccessFile(file, _overrides);
+  }
+
+  @override
+  Future<RandomAccessFile> open({
+    FileMode mode = FileMode.read,
+  }) async {
+    final file = await _file.open(mode: mode);
+    return _TrackingRandomAccessFile(file, _overrides);
+  }
+
+  @override
+  String readAsStringSync({
+    Encoding encoding = utf8,
+  }) {
+    return _file.readAsStringSync(encoding: encoding);
+  }
+
+  @override
+  Future<String> readAsString({
+    Encoding encoding = utf8,
+  }) {
+    return _file.readAsString(encoding: encoding);
+  }
+
+  @override
+  Uint8List readAsBytesSync() {
+    return _file.readAsBytesSync();
+  }
+
+  @override
+  Future<Uint8List> readAsBytes() {
+    return _file.readAsBytes();
+  }
+
+  @override
+  void writeAsStringSync(
+    String contents, {
+    FileMode mode = FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) {
+    _file.writeAsStringSync(
+      contents,
+      mode: mode,
+      encoding: encoding,
+      flush: flush,
+    );
+  }
+
+  @override
+  Future<File> writeAsString(
+    String contents, {
+    FileMode mode = FileMode.write,
+    Encoding encoding = utf8,
+    bool flush = false,
+  }) async {
+    await _file.writeAsString(
+      contents,
+      mode: mode,
+      encoding: encoding,
+      flush: flush,
+    );
+    return this;
+  }
+
+  @override
+  void writeAsBytesSync(
+    List<int> bytes, {
+    FileMode mode = FileMode.write,
+    bool flush = false,
+  }) {
+    _file.writeAsBytesSync(bytes, mode: mode, flush: flush);
+  }
+
+  @override
+  Future<File> writeAsBytes(
+    List<int> bytes, {
+    FileMode mode = FileMode.write,
+    bool flush = false,
+  }) async {
+    await _file.writeAsBytes(bytes, mode: mode, flush: flush);
+    return this;
+  }
+
+  @override
+  void deleteSync({
+    bool recursive = false,
+  }) {
+    _file.deleteSync(recursive: recursive);
+  }
+
+  @override
+  Future<FileSystemEntity> delete({
+    bool recursive = false,
+  }) {
+    return _file.delete(recursive: recursive);
+  }
+
+  @override
+  File renameSync(String newPath) {
+    final file = _file.renameSync(newPath);
+    return _TrackingFile(file, _overrides);
+  }
+
+  @override
+  Future<File> rename(String newPath) async {
+    final file = await _file.rename(newPath);
+    return _TrackingFile(file, _overrides);
+  }
+
+  @override
+  FileStat statSync() {
+    return _file.statSync();
+  }
+
+  @override
+  Future<FileStat> stat() {
+    return _file.stat();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    return super.noSuchMethod(invocation);
+  }
+}
+
+final class _TrackingRandomAccessFile implements RandomAccessFile {
+  _TrackingRandomAccessFile(this._file, this._overrides);
+
+  final RandomAccessFile _file;
+  final TrackingIoOverrides _overrides;
+
+  @override
+  String get path => _file.path;
+
+  @override
+  Future<RandomAccessFile> writeFrom(
+    List<int> buffer, [
+    int start = 0,
+    int? end,
+  ]) async {
+    await _file.writeFrom(buffer, start, end);
+    return this;
+  }
+
+  @override
+  void writeFromSync(
+    List<int> buffer, [
+    int start = 0,
+    int? end,
+  ]) {
+    _file.writeFromSync(buffer, start, end);
+  }
+
+  @override
+  Future<RandomAccessFile> flush() {
+    final flush = _file.flush().then((_) {
+      return this;
+    });
+    _overrides._trackFlush(flush);
+    return flush;
+  }
+
+  @override
+  void flushSync() {
+    _file.flushSync();
+  }
+
+  @override
+  Future<void> close() {
+    return _file.close();
+  }
+
+  @override
+  void closeSync() {
+    _file.closeSync();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    return super.noSuchMethod(invocation);
+  }
+}


### PR DESCRIPTION
The beta nightly exposed a race in the buffered file writer tests where `fakeAsyncWithDrain` guessed when real file I/O had settled.

Add a test-only `IOOverrides` wrapper that delegates to the real filesystem while tracking `RandomAccessFile.flush()` completions, then wait for those flushes before continuing fake-time assertions.

Verified locally with `dart analyze`, `dart test`, and a clean `dart:beta` linux/amd64 container run.