### PR TITLE
Fix missing source location in SimpleConsoleMessageFormatter

### DIFF
--- a/packages/chirp/CHANGELOG.md
+++ b/packages/chirp/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## Unreleased
 
-- **Fix** `SimpleConsoleMessageFormatter` now reports `requiresCallerInfo` correctly, so the source location shows up again.
-  It renders `file:line`, the method name and the caller-derived class name, but never asked the logger to capture the stack trace.
-  The location only appeared when some *other* writer (e.g. a file writer with `JsonLogFormatter`) happened to request caller info.
-  `requiresCallerInfo` now follows the display options — `showCaller || showInstance` — so `SimpleConsoleMessageFormatter(showCaller: false, showInstance: false)` still skips the expensive `StackTrace.current` capture.
+- **Fix** `SimpleConsoleMessageFormatter` requests caller info again, restoring the missing source location
 
 ## 0.9.0
 

--- a/packages/chirp/CHANGELOG.md
+++ b/packages/chirp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Chirp Changelog
 
+## Unreleased
+
+- **Fix** `SimpleConsoleMessageFormatter` now reports `requiresCallerInfo` correctly, so the source location shows up again.
+  It renders `file:line`, the method name and the caller-derived class name, but never asked the logger to capture the stack trace.
+  The location only appeared when some *other* writer (e.g. a file writer with `JsonLogFormatter`) happened to request caller info.
+  `requiresCallerInfo` now follows the display options — `showCaller || showInstance` — so `SimpleConsoleMessageFormatter(showCaller: false, showInstance: false)` still skips the expensive `StackTrace.current` capture.
+
 ## 0.9.0
 
 - **New** Lazy message construction — pass `() => 'expensive $message'` to any log method.

--- a/packages/chirp/CHANGELOG.md
+++ b/packages/chirp/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Fix** `SimpleConsoleMessageFormatter` requests caller info again, restoring the missing source location
+- **Fix** `SimpleConsoleMessageFormatter` requests caller info again, restoring the missing source location ([#46](https://github.com/passsy/chirp/issues/46))
 
 ## 0.9.0
 

--- a/packages/chirp/lib/src/formatters/simple_console_message_formatter.dart
+++ b/packages/chirp/lib/src/formatters/simple_console_message_formatter.dart
@@ -73,6 +73,16 @@ class SimpleConsoleMessageFormatter extends SpanBasedFormatter {
     super.spanTransformers,
   });
 
+  /// Requires caller info when it renders anything derived from the stack
+  /// trace: the source location and method name ([showCaller]), or the class
+  /// label ([showInstance]), which falls back to the caller-derived class name
+  /// when the record carries no instance.
+  ///
+  /// Construct the formatter with `showCaller: false, showInstance: false` to
+  /// opt out of the expensive `StackTrace.current` capture.
+  @override
+  bool get requiresCallerInfo => showCaller || showInstance;
+
   @override
   LogSpan buildSpan(LogRecord record) {
     return _buildSimpleLogSpan(

--- a/packages/chirp/test/simple_console_message_formatter_test.dart
+++ b/packages/chirp/test/simple_console_message_formatter_test.dart
@@ -365,6 +365,74 @@ void main() {
       expect(result, contains('_TestClass@$hash'));
       expect(result, isNot(contains('DifferentClass@')));
     });
+
+    group('requiresCallerInfo', () {
+      test('is true by default', () {
+        expect(SimpleConsoleMessageFormatter().requiresCallerInfo, isTrue);
+      });
+
+      test('stays true for showCaller alone', () {
+        final formatter = SimpleConsoleMessageFormatter(
+          showCaller: true,
+          showInstance: false,
+        );
+
+        expect(formatter.requiresCallerInfo, isTrue);
+      });
+
+      test('stays true for showInstance alone', () {
+        // ClassName.fromRecord falls back to the caller-derived class name
+        // when the record carries no instance.
+        final formatter = SimpleConsoleMessageFormatter(
+          showCaller: false,
+          showInstance: true,
+        );
+
+        expect(formatter.requiresCallerInfo, isTrue);
+      });
+
+      test('is false when neither caller nor instance is shown', () {
+        final formatter = SimpleConsoleMessageFormatter(
+          showCaller: false,
+          showInstance: false,
+        );
+
+        expect(formatter.requiresCallerInfo, isFalse);
+      });
+
+      test('logger prints the location without a second writer', () {
+        final messages = <String>[];
+        ChirpLogger()
+            .addConsoleWriter(
+              formatter: SimpleConsoleMessageFormatter(),
+              output: messages.add,
+            )
+            .info('hello');
+
+        expect(
+          messages.single,
+          matches(RegExp(r'simple_console_message_formatter_test:\d+')),
+        );
+      });
+
+      test('logger skips caller capture when the formatter opts out', () {
+        final messages = <String>[];
+        ChirpLogger()
+            .addConsoleWriter(
+              formatter: SimpleConsoleMessageFormatter(
+                showCaller: false,
+                showInstance: false,
+              ),
+              output: messages.add,
+            )
+            .info('hello');
+
+        expect(
+          messages.single,
+          isNot(matches(RegExp(r'simple_console_message_formatter_test:\d+'))),
+        );
+      });
+    });
   });
 
   group('FullTimestamp', () {


### PR DESCRIPTION
Fixes #46

`SimpleConsoleMessageFormatter` renders `file:line`, the method name and the caller-derived class name, but never overrode `ChirpFormatter.requiresCallerInfo` (default `false`). The logger only captures `StackTrace.current` when some writer or interceptor asks for it, so the location silently disappeared:

```dart
Chirp.root = ChirpLogger()..addConsoleWriter(formatter: SimpleConsoleMessageFormatter());
Chirp.root.info('hello');
// 10:30:45.123 [info] - hello        <- no location, although showCaller defaults to true
```

It reappeared as soon as an unrelated writer requested caller info (e.g. a file writer with `JsonLogFormatter`) — action at a distance that is hard to debug.

`requiresCallerInfo` now derives from the display options, the way `RainbowMessageFormatter` already does:

```dart
@override
bool get requiresCallerInfo => showCaller || showInstance;
```

`showInstance` counts because `ClassName.fromRecord` falls back to the caller-derived class name when the record carries no instance. The performance contract stays intact: `SimpleConsoleMessageFormatter(showCaller: false, showInstance: false)` reports `false` and skips the expensive capture.
