### PR TITLE
Stabilize fake async file I/O tests

### DIFF
--- a/packages/chirp/test/fake_async_with_drain.dart
+++ b/packages/chirp/test/fake_async_with_drain.dart
@@ -2,88 +2,103 @@ import 'dart:async';
 
 import 'package:fake_async/fake_async.dart';
 
-/// Pending drain completers, managed by [fakeAsyncWithDrain].
-List<Completer<void>>? _drainCompleters;
+import 'tracking_io_overrides.dart';
+
+/// Controls fake time and tracked file I/O inside [fakeAsyncWithDrain].
+final class AsyncIoContext {
+  AsyncIoContext._(this._fake, this._io);
+
+  final FakeAsync _fake;
+  final TrackingIoOverrides _io;
+  final List<Completer<void>> _drainCompleters = [];
+
+  /// Advances fake time and fires timers due within [duration].
+  void elapse(Duration duration) => _fake.elapse(duration);
+
+  /// Runs all microtasks queued in the fake async zone.
+  void flushMicrotasks() => _fake.flushMicrotasks();
+
+  /// Completes after the next tracked file flush finishes.
+  TrackingIoTrap trapFlush() => _io.trapFlush();
+
+  /// Completes after tracked file I/O and its fake-zone continuations settle.
+  Future<void> drain() {
+    final completer = Completer<void>();
+    _drainCompleters.add(completer);
+    return completer.future;
+  }
+
+  void _completeDrainRequests() {
+    while (_drainCompleters.isNotEmpty) {
+      _drainCompleters.removeAt(0).complete();
+    }
+  }
+}
 
 /// Runs [callback] inside fakeAsync with support for real I/O draining.
 ///
-/// Inside the callback, call `await drainEvent()` after triggering async
+/// Inside the callback, call `await async.drain()` after triggering async
 /// file I/O (e.g. via `async.elapse()` that fires a buffered flush timer)
-/// to let the real event loop deliver I/O completion callbacks. The outer
-/// loop then flushes fakeAsync microtasks so guards like `_pendingFlush`
-/// are cleared before the next batch.
+/// to wait for all tracked file operations to complete. The outer loop then
+/// flushes fakeAsync microtasks so guards like `_pendingFlush` are cleared
+/// before the next batch.
 ///
 /// Modelled after Flutter's `runAsync` pattern from
 /// `AutomatedTestWidgetsFlutterBinding`.
 Future<void> fakeAsyncWithDrain(
-  Future<void> Function(FakeAsync async) callback,
+  Future<void> Function(AsyncIoContext async) callback,
 ) async {
   final fake = FakeAsync();
+  final io = TrackingIoOverrides();
+  final async = AsyncIoContext._(fake, io);
   var done = false;
   Object? caughtError;
   StackTrace? caughtStack;
-  final completers = <Completer<void>>[];
-  _drainCompleters = completers;
 
-  fake.run((_) {
-    callback(fake).then((_) {
-      done = true;
-    }, onError: (Object e, StackTrace s) {
-      caughtError = e;
-      caughtStack = s;
-      done = true;
+  await io.run(() async {
+    fake.run((_) {
+      callback(async).then((_) {
+        done = true;
+      }, onError: (Object e, StackTrace s) {
+        caughtError = e;
+        caughtStack = s;
+        done = true;
+      });
     });
-  });
 
-  while (!done) {
-    // Settle pending I/O: yield to the real event loop so that
-    // RawReceivePort callbacks (from writeFrom / flush / close) are
-    // delivered, then flush fake-zone microtasks to run continuations.
-    // Multiple rounds handle chained I/O (writeFrom completes → code
-    // continues → file.flush starts → file.flush completes → …).
-    await fake.settleIo();
-    // Complete pending drainEvent() calls.
-    while (completers.isNotEmpty) {
-      completers.removeAt(0).complete();
+    while (!done) {
+      // Settle pending I/O, including chains where completing one operation
+      // starts another from a fake-zone continuation.
+      await fake.settleIo(io);
+
+      async._completeDrainRequests();
+
+      // Process test continuations and any I/O they start.
+      fake.run((_) => fake.flushMicrotasks());
     }
-    // Process test continuations and settle any new I/O they start.
-    fake.run((_) => fake.flushMicrotasks());
-  }
-
-  _drainCompleters = null;
+  });
 
   if (caughtError != null) {
     Error.throwWithStackTrace(caughtError!, caughtStack!);
   }
 }
 
-/// Yields control from a [fakeAsyncWithDrain] callback to let the real
-/// event loop process pending I/O completion callbacks.
-///
-/// Returns a [Future] that completes when the [fakeAsyncWithDrain] outer
-/// loop has drained real events and flushed fake microtasks. This ensures
-/// async I/O guards like `_pendingFlush` are cleared between batches.
-Future<void> drainEvent() {
-  final completers = _drainCompleters;
-  assert(completers != null,
-      'drainEvent() must be called inside fakeAsyncWithDrain');
-  final completer = Completer<void>();
-  completers!.add(completer);
-  return completer.future;
-}
-
 extension on FakeAsync {
-  /// Yields to the real event loop multiple times and flushes fake-zone
-  /// microtasks after each yield. This lets chained async I/O operations
-  /// complete (e.g. writeFrom → flush → close, where each completion
-  /// triggers the next operation).
-  Future<void> settleIo() async {
-    // Chained async I/O (writeFrom → .whenComplete → flush → close) needs
-    // multiple event-loop yields to fully settle. 10 rounds handles deep
-    // chains reliably, even on slow CI containers.
-    for (var i = 0; i < 10; i++) {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
+  /// Waits until tracked file I/O and the fake-zone continuations it schedules
+  /// reach quiescence. Fake timers are not advanced.
+  Future<void> settleIo(TrackingIoOverrides io) async {
+    while (true) {
       run((_) => flushMicrotasks());
+
+      if (!io.hasPendingOperations) {
+        return;
+      }
+
+      // dart:io futures contain continuations registered in FakeAsync's zone.
+      // Give the real event loop a turn for native I/O, then process those
+      // continuations above. Keep going until the tracked operation count,
+      // rather than an arbitrary number of turns, reaches zero.
+      await Future<void>.delayed(Duration.zero);
     }
   }
 }

--- a/packages/chirp/test/fake_async_with_drain_test.dart
+++ b/packages/chirp/test/fake_async_with_drain_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import 'fake_async_with_drain.dart';
+
+void main() {
+  test('drain waits for parallel file operations', () async {
+    final tempDir = Directory.systemTemp.createTempSync('chirp_io_drain_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+
+    await fakeAsyncWithDrain((async) async {
+      final firstFile = File('${tempDir.path}/first.log');
+      final secondFile = File('${tempDir.path}/second.log');
+      final writes = [
+        firstFile.writeAsString('first'),
+        secondFile.writeAsString('second'),
+      ];
+
+      await async.drain();
+      await Future.wait(writes);
+
+      expect(firstFile.readAsStringSync(), 'first');
+      expect(secondFile.readAsStringSync(), 'second');
+    });
+  });
+
+  test('drain settles chained random access file operations', () async {
+    final tempDir = Directory.systemTemp.createTempSync('chirp_io_chain_');
+    addTearDown(() => tempDir.deleteSync(recursive: true));
+
+    await fakeAsyncWithDrain((async) async {
+      final file = File('${tempDir.path}/app.log');
+      final handle = file.openSync(mode: FileMode.write);
+      final operations = handle
+          .writeFrom(utf8.encode('message'))
+          .then((handle) => handle.flush())
+          .then((handle) => handle.close());
+
+      await async.drain();
+      await operations;
+
+      expect(file.readAsStringSync(), 'message');
+    });
+  });
+}

--- a/packages/chirp/test/rotating_file_writer_test.dart
+++ b/packages/chirp/test/rotating_file_writer_test.dart
@@ -13,7 +13,6 @@ import 'package:test/test.dart';
 
 import 'fake_async_with_drain.dart';
 import 'test_log_record.dart';
-import 'tracking_io_overrides.dart';
 
 void main() {
   group('SimpleFileFormatter', () {
@@ -394,13 +393,13 @@ void main() {
         // Advance past the flushInterval — fires the flush timer which
         // starts real async file I/O.
         async.elapse(const Duration(seconds: 2));
-        await drainEvent();
+        await async.drain();
 
         final content = File(logPath).readAsStringSync();
         expect(content, contains('Buffered info'));
 
         writer.close();
-        await drainEvent();
+        await async.drain();
       });
     });
 
@@ -1098,7 +1097,7 @@ void main() {
 
           // Force rotation — should flush buffer to the old file first
           await writer.forceRotate();
-          await drainEvent();
+          await async.drain();
 
           // Write after rotation
           writer.write(
@@ -1118,7 +1117,7 @@ void main() {
               reason: 'Pre-rotation record should be in rotated file');
 
           await writer.close();
-          await drainEvent();
+          await async.drain();
         });
       });
     });
@@ -1614,7 +1613,7 @@ void main() {
 
         // Wait for timer to fire and settle async I/O
         async.elapse(const Duration(milliseconds: 50));
-        await drainEvent();
+        await async.drain();
 
         // Now file should exist
         expect(File(logPath).existsSync(), isTrue,
@@ -1624,7 +1623,7 @@ void main() {
         expect(content, contains('Message 1'));
 
         writer.close();
-        await drainEvent();
+        await async.drain();
       });
     });
 
@@ -1648,7 +1647,7 @@ void main() {
 
         // Wait for timer and settle async I/O
         async.elapse(const Duration(milliseconds: 100));
-        await drainEvent();
+        await async.drain();
 
         // All 3 messages should be written in one batch
         final content = File(logPath).readAsStringSync();
@@ -1660,51 +1659,48 @@ void main() {
         expect(lines.length, 3, reason: 'All 3 messages batched in one flush');
 
         writer.close();
-        await drainEvent();
+        await async.drain();
       });
     });
 
     test('timer resets after flush, next write starts new timer', () async {
-      final io = TrackingIoOverrides();
-      await io.run(() async {
-        await fakeAsyncWithDrain((async) async {
-          final tempDir = createTempDir();
-          final logPath = '${tempDir.path}/app.log';
-          final writer = RotatingFileWriter(
-            baseFilePathProvider: () => logPath,
-            flushStrategy: FlushStrategy.buffered,
-          );
+      await fakeAsyncWithDrain((async) async {
+        final tempDir = createTempDir();
+        final logPath = '${tempDir.path}/app.log';
+        final writer = RotatingFileWriter(
+          baseFilePathProvider: () => logPath,
+          flushStrategy: FlushStrategy.buffered,
+        );
 
-          // First batch
-          writer.write(testRecord(message: 'Batch 1'));
-          final firstFlush = io.trapFlush();
-          async.elapse(const Duration(seconds: 1));
-          await firstFlush.wait();
-          async.flushMicrotasks();
+        // First batch
+        writer.write(testRecord(message: 'Batch 1'));
+        final firstFlush = async.trapFlush();
+        async.elapse(const Duration(seconds: 1));
+        await firstFlush.wait();
+        async.flushMicrotasks();
 
-          final content = File(logPath).readAsStringSync();
-          expect(content, contains('Batch 1'));
-          expect(content, isNot(contains('Batch 2')));
+        final content = File(logPath).readAsStringSync();
+        expect(content, contains('Batch 1'));
+        expect(content, isNot(contains('Batch 2')));
 
-          // Second batch - starts new timer
-          writer.write(testRecord(message: 'Batch 2'));
+        // Second batch - starts new timer
+        writer.write(testRecord(message: 'Batch 2'));
 
-          // Immediately, batch 2 not flushed yet
-          expect(File(logPath).readAsStringSync(), isNot(contains('Batch 2')),
-              reason: 'Batch 2 not yet flushed');
+        // Immediately, batch 2 not flushed yet
+        expect(File(logPath).readAsStringSync(), isNot(contains('Batch 2')),
+            reason: 'Batch 2 not yet flushed');
 
-          final secondFlush = io.trapFlush();
-          async.elapse(const Duration(seconds: 1));
-          await secondFlush.wait();
-          async.flushMicrotasks();
+        final secondFlush = async.trapFlush();
+        async.elapse(const Duration(seconds: 1));
+        await secondFlush.wait();
+        async.flushMicrotasks();
 
-          final content2 = File(logPath).readAsStringSync();
-          expect(content2, contains('Batch 1'));
-          expect(content2, contains('Batch 2'));
+        final content2 = File(logPath).readAsStringSync();
+        expect(content2, contains('Batch 1'));
+        expect(content2, contains('Batch 2'));
 
-          await writer.close();
-          await drainEvent();
-        });
+        await writer.close();
+        await async.drain();
       });
     });
 
@@ -1785,14 +1781,14 @@ void main() {
 
         // Wait for new timer
         async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+        await async.drain();
 
         content = File(logPath).readAsStringSync();
         expect(content, contains('Error'));
         expect(content, contains('Info after error'));
 
         writer.close();
-        await drainEvent();
+        await async.drain();
       });
     });
 
@@ -1835,21 +1831,21 @@ void main() {
 
         // Flush manually before timer fires
         await writer.flush();
-        await drainEvent();
+        await async.drain();
 
         final content = File(logPath).readAsStringSync();
         expect(content, contains('Message 1'));
 
         // Wait past original timer time
         async.elapse(const Duration(seconds: 10));
-        await drainEvent();
+        await async.drain();
 
         // No duplicate write from timer (it was cancelled)
         expect(File(logPath).readAsStringSync(), content,
             reason: 'Timer should be cancelled, no duplicate write');
 
         await writer.close();
-        await drainEvent();
+        await async.drain();
       });
     });
 
@@ -1867,6 +1863,7 @@ void main() {
         writer.write(testRecord(message: 'Batch 1'));
 
         // Timer fires, starts async flush (_pendingFlush becomes non-null)
+        final firstFlush = async.trapFlush();
         async.elapse(const Duration(seconds: 1));
 
         // While the async flush is in-flight, write another record.
@@ -1874,7 +1871,8 @@ void main() {
         writer.write(testRecord(message: 'During flush'));
 
         // Let the first flush complete — whenComplete should restart the timer
-        await drainEvent();
+        await firstFlush.wait();
+        async.flushMicrotasks();
 
         // Batch 1 should be on disk now
         final content1 = File(logPath).readAsStringSync();
@@ -1883,8 +1881,10 @@ void main() {
             reason: 'Record written during flush should still be buffered');
 
         // Advance time for the restarted timer to fire
+        final secondFlush = async.trapFlush();
         async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+        await secondFlush.wait();
+        async.flushMicrotasks();
 
         // Now the second record should be flushed
         final content2 = File(logPath).readAsStringSync();
@@ -1894,64 +1894,61 @@ void main() {
                 'after the restarted timer fires');
 
         await writer.close();
-        await drainEvent();
+        await async.drain();
       });
     });
 
     test('sustained logging: each flush resets timer for next batch', () async {
-      final io = TrackingIoOverrides();
-      await io.run(() async {
-        await fakeAsyncWithDrain((async) async {
-          final tempDir = createTempDir();
-          final logPath = '${tempDir.path}/app.log';
-          final writer = RotatingFileWriter(
-            baseFilePathProvider: () => logPath,
-            flushStrategy: FlushStrategy.buffered,
-          );
+      await fakeAsyncWithDrain((async) async {
+        final tempDir = createTempDir();
+        final logPath = '${tempDir.path}/app.log';
+        final writer = RotatingFileWriter(
+          baseFilePathProvider: () => logPath,
+          flushStrategy: FlushStrategy.buffered,
+        );
 
-          // Batch 1
-          writer.write(testRecord(message: 'Batch 1 - Msg 1'));
-          writer.write(testRecord(message: 'Batch 1 - Msg 2'));
-          final firstFlush = io.trapFlush();
-          async.elapse(const Duration(seconds: 1));
-          await firstFlush.wait();
-          async.flushMicrotasks();
+        // Batch 1
+        writer.write(testRecord(message: 'Batch 1 - Msg 1'));
+        writer.write(testRecord(message: 'Batch 1 - Msg 2'));
+        final firstFlush = async.trapFlush();
+        async.elapse(const Duration(seconds: 1));
+        await firstFlush.wait();
+        async.flushMicrotasks();
 
-          var content = File(logPath).readAsStringSync();
-          expect(content, contains('Batch 1 - Msg 1'));
-          expect(content, contains('Batch 1 - Msg 2'));
+        var content = File(logPath).readAsStringSync();
+        expect(content, contains('Batch 1 - Msg 1'));
+        expect(content, contains('Batch 1 - Msg 2'));
 
-          // Batch 2
-          writer.write(testRecord(message: 'Batch 2 - Msg 1'));
-          final secondFlush = io.trapFlush();
-          async.elapse(const Duration(seconds: 1));
-          await secondFlush.wait();
-          async.flushMicrotasks();
+        // Batch 2
+        writer.write(testRecord(message: 'Batch 2 - Msg 1'));
+        final secondFlush = async.trapFlush();
+        async.elapse(const Duration(seconds: 1));
+        await secondFlush.wait();
+        async.flushMicrotasks();
 
-          content = File(logPath).readAsStringSync();
-          expect(content, contains('Batch 2 - Msg 1'));
+        content = File(logPath).readAsStringSync();
+        expect(content, contains('Batch 2 - Msg 1'));
 
-          // Batch 3
-          writer.write(testRecord(message: 'Batch 3 - Msg 1'));
-          writer.write(testRecord(message: 'Batch 3 - Msg 2'));
-          writer.write(testRecord(message: 'Batch 3 - Msg 3'));
-          final thirdFlush = io.trapFlush();
-          async.elapse(const Duration(seconds: 1));
-          await thirdFlush.wait();
-          async.flushMicrotasks();
+        // Batch 3
+        writer.write(testRecord(message: 'Batch 3 - Msg 1'));
+        writer.write(testRecord(message: 'Batch 3 - Msg 2'));
+        writer.write(testRecord(message: 'Batch 3 - Msg 3'));
+        final thirdFlush = async.trapFlush();
+        async.elapse(const Duration(seconds: 1));
+        await thirdFlush.wait();
+        async.flushMicrotasks();
 
-          // All batches flushed
-          content = File(logPath).readAsStringSync();
-          expect(content, contains('Batch 1 - Msg 1'));
-          expect(content, contains('Batch 1 - Msg 2'));
-          expect(content, contains('Batch 2 - Msg 1'));
-          expect(content, contains('Batch 3 - Msg 1'));
-          expect(content, contains('Batch 3 - Msg 2'));
-          expect(content, contains('Batch 3 - Msg 3'));
+        // All batches flushed
+        content = File(logPath).readAsStringSync();
+        expect(content, contains('Batch 1 - Msg 1'));
+        expect(content, contains('Batch 1 - Msg 2'));
+        expect(content, contains('Batch 2 - Msg 1'));
+        expect(content, contains('Batch 3 - Msg 1'));
+        expect(content, contains('Batch 3 - Msg 2'));
+        expect(content, contains('Batch 3 - Msg 3'));
 
-          await writer.close();
-          await drainEvent();
-        });
+        await writer.close();
+        await async.drain();
       });
     });
 
@@ -1982,11 +1979,11 @@ void main() {
         ));
 
         // Let the async flush complete
-        await drainEvent();
+        await async.drain();
 
         // Close to ensure everything is flushed
         await writer.close();
-        await drainEvent();
+        await async.drain();
 
         // All records must be on disk in chronological order
         final content = File(logPath).readAsStringSync();
@@ -2013,7 +2010,7 @@ void main() {
         // Write a record and let it flush
         writer.write(testRecord(message: 'First'));
         async.elapse(const Duration(seconds: 1));
-        await drainEvent();
+        await async.drain();
 
         expect(File(logPath).readAsStringSync(), contains('First'));
 
@@ -2024,11 +2021,11 @@ void main() {
         writer.write(testRecord(message: 'During flush'));
 
         await flushFuture;
-        await drainEvent();
+        await async.drain();
 
         // Now close — should drain _pendingRecords before closing
         await writer.close();
-        await drainEvent();
+        await async.drain();
 
         final content = File(logPath).readAsStringSync();
         expect(content, contains('First'));

--- a/packages/chirp/test/tracking_io_overrides.dart
+++ b/packages/chirp/test/tracking_io_overrides.dart
@@ -6,8 +6,13 @@ import 'dart:typed_data';
 /// Tracks file I/O created through [File] while delegating to the real file
 /// system.
 final class TrackingIoOverrides extends IOOverrides {
+  final Zone _trackingZone = Zone.current;
+
   int _completedFlushes = 0;
   final List<_FlushWaiter> _flushWaiters = [];
+  int _pendingOperations = 0;
+
+  bool get hasPendingOperations => _pendingOperations > 0;
 
   Future<T> run<T>(Future<T> Function() body) {
     return IOOverrides.runWithIOOverrides(body, this);
@@ -26,11 +31,34 @@ final class TrackingIoOverrides extends IOOverrides {
     return _TrackingFile(file, this);
   }
 
-  void _trackFlush(Future<RandomAccessFile> flush) {
-    flush.whenComplete(() {
+  Future<T> _trackOperation<T>(
+    Future<T> operation, {
+    bool isFlush = false,
+  }) {
+    _pendingOperations++;
+
+    // Register the tracking callback outside FakeAsync's zone. Otherwise the
+    // callback that marks the operation complete would itself be held in the
+    // fake microtask queue while the test waits for the operation to settle.
+    _trackingZone.run(() {
+      operation.then<void>(
+        (_) => _completeOperation(isFlush: isFlush),
+        onError: (Object _, StackTrace __) {
+          _completeOperation(isFlush: isFlush);
+        },
+      );
+    });
+
+    return operation;
+  }
+
+  void _completeOperation({required bool isFlush}) {
+    if (isFlush) {
       _completedFlushes++;
       _completeReadyFlushWaiters();
-    });
+    }
+
+    _pendingOperations--;
   }
 
   Future<void> _waitForFlushAfter(int completedFlushes) {
@@ -66,12 +94,8 @@ final class TrackingIoTrap {
   final TrackingIoOverrides _overrides;
   final int _completedFlushesAtCreation;
 
-  Future<void> wait({
-    Duration timeout = const Duration(seconds: 5),
-  }) {
-    return _overrides
-        ._waitForFlushAfter(_completedFlushesAtCreation)
-        .timeout(timeout);
+  Future<void> wait() {
+    return _overrides._waitForFlushAfter(_completedFlushesAtCreation);
   }
 }
 
@@ -116,7 +140,7 @@ final class _TrackingFile implements File {
 
   @override
   Future<bool> exists() {
-    return _file.exists();
+    return _overrides._trackOperation(_file.exists());
   }
 
   @override
@@ -126,7 +150,7 @@ final class _TrackingFile implements File {
 
   @override
   Future<int> length() {
-    return _file.length();
+    return _overrides._trackOperation(_file.length());
   }
 
   @override
@@ -140,9 +164,9 @@ final class _TrackingFile implements File {
   @override
   Future<RandomAccessFile> open({
     FileMode mode = FileMode.read,
-  }) async {
-    final file = await _file.open(mode: mode);
-    return _TrackingRandomAccessFile(file, _overrides);
+  }) {
+    final open = _overrides._trackOperation(_file.open(mode: mode));
+    return open.then((file) => _TrackingRandomAccessFile(file, _overrides));
   }
 
   @override
@@ -156,7 +180,9 @@ final class _TrackingFile implements File {
   Future<String> readAsString({
     Encoding encoding = utf8,
   }) {
-    return _file.readAsString(encoding: encoding);
+    return _overrides._trackOperation(
+      _file.readAsString(encoding: encoding),
+    );
   }
 
   @override
@@ -166,7 +192,7 @@ final class _TrackingFile implements File {
 
   @override
   Future<Uint8List> readAsBytes() {
-    return _file.readAsBytes();
+    return _overrides._trackOperation(_file.readAsBytes());
   }
 
   @override
@@ -190,14 +216,16 @@ final class _TrackingFile implements File {
     FileMode mode = FileMode.write,
     Encoding encoding = utf8,
     bool flush = false,
-  }) async {
-    await _file.writeAsString(
-      contents,
-      mode: mode,
-      encoding: encoding,
-      flush: flush,
+  }) {
+    final write = _overrides._trackOperation(
+      _file.writeAsString(
+        contents,
+        mode: mode,
+        encoding: encoding,
+        flush: flush,
+      ),
     );
-    return this;
+    return write.then((_) => this);
   }
 
   @override
@@ -214,9 +242,11 @@ final class _TrackingFile implements File {
     List<int> bytes, {
     FileMode mode = FileMode.write,
     bool flush = false,
-  }) async {
-    await _file.writeAsBytes(bytes, mode: mode, flush: flush);
-    return this;
+  }) {
+    final write = _overrides._trackOperation(
+      _file.writeAsBytes(bytes, mode: mode, flush: flush),
+    );
+    return write.then((_) => this);
   }
 
   @override
@@ -230,7 +260,9 @@ final class _TrackingFile implements File {
   Future<FileSystemEntity> delete({
     bool recursive = false,
   }) {
-    return _file.delete(recursive: recursive);
+    return _overrides._trackOperation(
+      _file.delete(recursive: recursive),
+    );
   }
 
   @override
@@ -240,9 +272,9 @@ final class _TrackingFile implements File {
   }
 
   @override
-  Future<File> rename(String newPath) async {
-    final file = await _file.rename(newPath);
-    return _TrackingFile(file, _overrides);
+  Future<File> rename(String newPath) {
+    final rename = _overrides._trackOperation(_file.rename(newPath));
+    return rename.then((file) => _TrackingFile(file, _overrides));
   }
 
   @override
@@ -252,7 +284,7 @@ final class _TrackingFile implements File {
 
   @override
   Future<FileStat> stat() {
-    return _file.stat();
+    return _overrides._trackOperation(_file.stat());
   }
 
   @override
@@ -275,9 +307,11 @@ final class _TrackingRandomAccessFile implements RandomAccessFile {
     List<int> buffer, [
     int start = 0,
     int? end,
-  ]) async {
-    await _file.writeFrom(buffer, start, end);
-    return this;
+  ]) {
+    final write = _overrides._trackOperation(
+      _file.writeFrom(buffer, start, end),
+    );
+    return write.then((_) => this);
   }
 
   @override
@@ -291,11 +325,11 @@ final class _TrackingRandomAccessFile implements RandomAccessFile {
 
   @override
   Future<RandomAccessFile> flush() {
-    final flush = _file.flush().then((_) {
-      return this;
-    });
-    _overrides._trackFlush(flush);
-    return flush;
+    final flush = _overrides._trackOperation(
+      _file.flush(),
+      isFlush: true,
+    );
+    return flush.then((_) => this);
   }
 
   @override
@@ -305,7 +339,7 @@ final class _TrackingRandomAccessFile implements RandomAccessFile {
 
   @override
   Future<void> close() {
-    return _file.close();
+    return _overrides._trackOperation(_file.close());
   }
 
   @override


### PR DESCRIPTION
The nightly Dart beta job exposed that `fakeAsyncWithDrain` treated ten one-millisecond event-loop turns as proof that file I/O had completed. A slower flush could outlive that window, allowing fake time to advance before the writer's completion callback restarted its timer.

Track asynchronous file operations through the existing I/O override and keep pumping real events plus fake-zone microtasks until those operations actually settle. Tests receive one `AsyncIoContext` for fake-time control, flush boundaries, and draining; its context-owned drain state also avoids interference between helper instances.

This preserves explicit flush traps for tests that need an exact boundary while making ordinary `drain()` calls deterministic for serial and parallel file operations.

Triggered by the [nightly Dart beta failure](https://github.com/passsy/chirp/actions/runs/32725211227/job/97424825281).
